### PR TITLE
nix: enable tests

### DIFF
--- a/typedefs.nix
+++ b/typedefs.nix
@@ -11,6 +11,7 @@ build-idris-package {
   name = "typedefs";
   version = "dev";
   src = ./.;
+  doCheck = true;
 
   idrisDeps = with idrisPackages; [
     tparsec


### PR DESCRIPTION
enable checks when building with nix, such that travis would also run the test suite