### PR TITLE
expose/reexport backends and term codec

### DIFF
--- a/parser.js/ParserJS.idr
+++ b/parser.js/ParserJS.idr
@@ -24,7 +24,7 @@ generateCode _          _         = "<error : unknown backend>"
 
 -- re-exports
 parseType : String -> Maybe (n : Nat ** TNamed n)
-parseType = parseTNamed
+parseType = parseTNamed 
 
 lib : FFI_Export FFI_JS "" []
 lib = Data (n ** TNamed n) "TNamedN" $

--- a/parser.js/ParserJS.idr
+++ b/parser.js/ParserJS.idr
@@ -1,8 +1,12 @@
-import Typedefs
+import public Typedefs
 import Parse
+import public TermParse
+import public TermWrite
 import Backend
 import Backend.Utils
 import Backend.Haskell
+import Backend.JSON
+import Backend.ReasonML
 
 getSource : JS_IO String
 getSource = foreign FFI_JS "getSource()" _
@@ -10,5 +14,15 @@ getSource = foreign FFI_JS "getSource()" _
 setResult : String -> JS_IO ()
 setResult = foreign FFI_JS "setResult(%0)" _
 
-main : JS_IO ()
-main = setResult $ parseTNamedThenStrFun !getSource (\td => print . generateDefs Haskell $ DPair.snd td)
+-- re-exports
+parseType : String -> Maybe (n : Nat ** TNamed n)
+parseType = parseTNamed
+
+generateHaskell : TNamed n -> Doc
+generateHaskell = generateDefs Haskell
+
+generateReason : TNamed n -> Doc
+generateReason = generateDefs ReasonML
+
+generateJSON : TNamed 0 -> Doc
+generateJSON = generate JSONDef

--- a/src/Provider.idr
+++ b/src/Provider.idr
@@ -12,7 +12,7 @@ import Parse
 %default total
 
 provideTP : String -> IO (Provider (n ** TDef n))
-provideTP s = case parseMaybe s tdef of
+provideTP s = case parseMaybe s tdefRec of
   Just r => pure $ Provide r
   Nothing => pure $ Error "parse error"
 

--- a/typedefs-parser-js.ipkg
+++ b/typedefs-parser-js.ipkg
@@ -8,4 +8,4 @@ sourcedir = parser.js
 
 pkgs = contrib, typedefs, js
 
-opts = "--codegen node"
+opts = "--codegen node --interface"

--- a/typedefs-parser-js.ipkg
+++ b/typedefs-parser-js.ipkg
@@ -6,6 +6,6 @@ main = ParserJS
 
 sourcedir = parser.js
 
-pkgs = typedefs, js
+pkgs = contrib, typedefs, js
 
-opts = "--codegen javascript"
+opts = "--codegen node"


### PR DESCRIPTION
@clayrat As far as I can see this PR is good to go. We do want the backend switch string Jelle mentioned yesterday, but we could do that in a separate PR.