### PR TITLE
Command line options

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -42,6 +42,22 @@
 }:
 
 let
+  config = {
+    packageOverrides = pkgs: {
+      idrisPackages = pkgs.idrisPackages.override {
+        # We override the 'idrisPackages' packaget set
+        # This means, that all these package definitions will 'see' eachother
+        #  e.g. if typedefs-parser depends on typedefs, callPackage will automatically inject it
+        # Add new idris packages to this list 
+        overrides = idrisPackagesNew: idrisPackagesOld: {
+          typedefs = idrisPackagesNew.callPackage ./typedefs.nix {};
+          typedefs-parser = idrisPackagesNew.callPackage ./typedefs-parser.nix {};
+          typedefs-parser-js = idrisPackagesNew.callPackage ./typedefs-parser-js.nix {};
+          typedefs-examples = idrisPackagesNew.callPackage ./typedefs-examples.nix {};
+        };
+      };
+    };
+  };
   syspkgs = import <nixpkgs> { };
   pinpkgs = syspkgs.fetchFromGitHub {
     owner = "NixOS";
@@ -51,19 +67,20 @@ let
     rev = "140a648e46f9a255849d938efd92930297258621";
     sha256 = "0az8ph3kf6pgz5xv2x1n4kiccyyq0p5h2rjqfwc5qh97lnqigmbf";
   };
-  usepkgs = if null == pkgs then
-             import pinpkgs {}
-            else
-              if 0 == pkgs then
-                import <nixpkgs> { }
-              else
-                import pkgs {};
+  usepkgs = (
+    if null == pkgs 
+    then import pinpkgs
+    else if 0 == pkgs 
+    then import <nixpkgs>
+    else import pkgs) { inherit config; };
   stdenv = usepkgs.stdenvAdapters.keepDebugInfo usepkgs.stdenv;
 
 in {
-  typedefs = usepkgs.callPackage ./typedefs.nix {};
-  typedefs-parser = usepkgs.callPackage ./typedefs-parser.nix {};
-  typedefs-parser-js = usepkgs.callPackage ./typedefs-parser-js.nix {};
-  typedefs-examples = usepkgs.callPackage ./typedefs-examples.nix {};
-
+  # This attribute set exposes what things will be built by a call to nix-build. See
+  # its as the "CI" entrypoint.
+  inherit (usepkgs.idrisPackages) 
+    typedefs 
+    typedefs-parser
+    typedefs-parser-js 
+    typedefs-examples;
 }

--- a/default.nix
+++ b/default.nix
@@ -54,6 +54,7 @@ let
           typedefs-parser = idrisPackagesNew.callPackage ./typedefs-parser.nix {};
           typedefs-parser-js = idrisPackagesNew.callPackage ./typedefs-parser-js.nix {};
           typedefs-examples = idrisPackagesNew.callPackage ./typedefs-examples.nix {};
+          optparse = idrisPackagesNew.callPackage ./optparse.nix {};
         };
       };
     };

--- a/optparse.nix
+++ b/optparse.nix
@@ -3,15 +3,15 @@ build-idris-package {
   name = "optparse";
   version = "2019-06-03";
   src = fetchFromGitHub {
-    owner = "HuwCampbell";
+    owner = "statebox";
     repo = "optparse-idris";
-    rev = "0d8f9fac9e2c1c8f2fe7f983de1d46906ea38778";
-    sha256 = "1djwjkc6z3qbz349znrzsi6jp2ai9nrzs97s2h3l8wq2h874zvl5"; # lib.fakeSha256; # This makes nix error out and give you the correct hash in stderr
+    rev = "bd5d52097f5f414be0f710f2a0cffb01a04e95fd";
+    sha256 = "0nr0hgmndnwsd65r9g49zgkdqsryrzg3c86pv5w2q88ybxplm0ap"; # lib.fakeSha256; # This makes nix error out and give you the correct hash in stderr
   };
   idrisDeps = [ lens wl-pprint ];
 
   meta = {
     description = "Minimal port of optparse-applicative to idris";
-    homepage = https://github.com/HuwCampbell/optparse-idris;
+    homepage = https://github.com/statebox/optparse-idris;
 };
 }

--- a/optparse.nix
+++ b/optparse.nix
@@ -1,0 +1,17 @@
+{ build-idris-package, fetchFromGitHub, lens, wl-pprint/*, lib*/}:
+build-idris-package {
+  name = "optparse";
+  version = "2019-06-03";
+  src = fetchFromGitHub {
+    owner = "HuwCampbell";
+    repo = "optparse-idris";
+    rev = "0d8f9fac9e2c1c8f2fe7f983de1d46906ea38778";
+    sha256 = "1djwjkc6z3qbz349znrzsi6jp2ai9nrzs97s2h3l8wq2h874zvl5"; # lib.fakeSha256; # This makes nix error out and give you the correct hash in stderr
+  };
+  idrisDeps = [ lens wl-pprint ];
+
+  meta = {
+    description = "Minimal port of optparse-applicative to idris";
+    homepage = https://github.com/HuwCampbell/optparse-idris;
+};
+}

--- a/parser/CommandLine.idr
+++ b/parser/CommandLine.idr
@@ -1,0 +1,101 @@
+module CommandLine
+
+import Options.Applicative
+
+%default total
+
+public export
+data InputFile = StringInput String
+               | FileInput String
+
+public export
+Show InputFile where
+  show StringInput = "command line input"
+  show (FileInput str) = str
+
+public export
+data OutputFile = StdOutput
+                | FileOutput String
+
+public export
+Show OutputFile where
+  show StdOutput = "stdout"
+  show (FileOutput str) = str
+
+stringInput : Parser InputFile
+stringInput = StringInput <$> strOption (long "inline" . short 'i')
+
+fileInput : Parser InputFile
+fileInput = FileInput <$> strOption (long "source" . short 's')
+
+parseInput : Parser InputFile
+parseInput = stringInput <|> fileInput
+
+stdOutput : Parser OutputFile
+stdOutput = flag' StdOutput (long "stdout")
+
+fileOutput : Parser OutputFile
+fileOutput = FileOutput <$> strOption (long "dest" . short 'd')
+
+parseOutput : Parser OutputFile
+parseOutput = fileOutput <|> stdOutput <|> pure StdOutput
+
+
+public export
+record TypedefOpts where
+  constructor MkTypedefOpts
+  input : InputFile
+  output : OutputFile
+
+public export
+data CommandLineOpts = Help | GenerateTDefOpt TypedefOpts | HelpFallback
+
+Show TypedefOpts where
+  show (MkTypedefOpts i o) = "input : " ++ show i ++ "output : " ++ show o
+
+export
+helpMessage : String
+helpMessage = """
+Welcome to Typedefs, programming language for types.
+
+Usage:
+  typedefs_parser (-i INLINE_TDEF | -s SOURCE) [-d DEST | --stdout]
+
+  --source, -s : path to the input file
+    example:
+      typedefs_parser -s bool.tdef
+
+  --inline, -i : input as a string inline
+    example:
+      typedefs_parser -i "(name bool (+ 1 1))" --stdout
+
+  --dest, -d : path to the destination file
+    example:
+      typedefs_parser -s bool.tdef project/typedefs/types.hs
+
+  --stdout : print the output on stdout
+    example:
+      typedefs_parser -i bool.tdef --stdout | grep "bool"
+"""
+
+export
+fallbackMessage : String
+fallbackMessage = """
+No arguments supplied, expected --help or -s SOURCE -d DEST.
+
+Typedefs allows you to define types using very general operations and
+generate seralizers and deserializers for a target language.
+
+If this is your first time head to https://typedefs.com for more information or use --help.
+"""
+
+parseTDefOptions : Parser TypedefOpts
+parseTDefOptions = MkTypedefOpts <$> parseInput <*> parseOutput
+
+export
+parseProgramOptions : Parser CommandLineOpts
+parseProgramOptions = (GenerateTDefOpt <$> parseTDefOptions) 
+                        <|> flag' Help (long "help" . short 'h') 
+                        <|> pure HelpFallback
+
+

--- a/parser/Parser.idr
+++ b/parser/Parser.idr
@@ -3,117 +3,27 @@ import Parse
 import Backend
 import Backend.Utils
 import Backend.Haskell
+import CommandLine
 
 import Options.Applicative
-
-%default total
-
-flag' : a -> (Option FlagParams a -> Option FlagParams a) -> Parser a
-flag' d f = OptP (f $ Opt defProps (FlagReader [] d))
-
-
-data InputFile = StringInput String
-               | FileInput String
-
-Show InputFile where
-  show StringInput = "command line input"
-  show (FileInput str) = str
-
-data OutputFile = StdOutput
-                | FileOutput String
-
-Show OutputFile where
-  show StdOutput = "stdout"
-  show (FileOutput str) = str
-
-stringInput : Parser InputFile
-stringInput = StringInput <$> strOption (long "inline" . short 'i')
-
-fileInput : Parser InputFile
-fileInput = FileInput <$> strOption (long "source" . short 's')
-
-parseInput : Parser InputFile
-parseInput = stringInput <|> fileInput
-
-stdOutput : Parser OutputFile
-stdOutput = flag' StdOutput (long "stdout")
-
-fileOutput : Parser OutputFile
-fileOutput = FileOutput <$> strOption (long "dest" . short 'd')
-
-parseOutput : Parser OutputFile
-parseOutput = fileOutput <|> stdOutput <|> pure StdOutput
-
-
-record TypedefOpts where
-  constructor MkTypedefOpts
-  input : InputFile
-  output : OutputFile
-
-data CommandLineOpts = Help | GenerateTDefOpt TypedefOpts | HelpFallback
-
-Show TypedefOpts where
-  show (MkTypedefOpts i o) = "input : " ++ show i ++ "output : " ++ show o
-
-helpMessage : String
-helpMessage = """
-Welcome to Typedefs, programming language for types.
-
-Usage:
-  typedefs_parser (-i INLINE_TDEF | -s SOURCE) [-d DEST | --stdout]
-
-  --source, -s : path to the input file
-    example:
-      typedefs_parser -s bool.tdef
-
-  --inline, -i : input as a string inline
-    example:
-      typedefs_parser -i "(name bool (+ 1 1))" --stdout
-
-  --dest, -d : path to the destination file
-    example:
-      typedefs_parser -i bool.tdef project/typedefs/types.hs
-
-  --stdout : print the output on stdout
-    example:
-      typedefs_parser -i bool.tdef --stdout | grep "bool"
-"""
-
-fallbackMessage : String
-fallbackMessage = """
-No arguments supplied, expected --help or -s SOURCE -d DEST.
-
-Typedefs allows you to define types using very general operations and
-generate seralizers and deserializers for a target language.
-
-If this is your first time head to https://typedefs.com for more information or use --help.
-"""
-
-parseTDefOptions : Parser TypedefOpts
-parseTDefOptions = MkTypedefOpts <$> parseInput <*> parseOutput
-
-parseProgramOptions : Parser CommandLineOpts
-parseProgramOptions = (GenerateTDefOpt <$> parseTDefOptions) 
-                        <|> flag' Help (long "help" . short 'h') 
-                        <|> pure HelpFallback
-
 
 processArgs : List String -> Either ParseError CommandLineOpts
 processArgs (_ :: opts) = runParserFully parseProgramOptions opts
 processArgs _ = Left (ErrorMsg "Not enough arguments")
 
-generateTDef : String -> Maybe String
-generateTDef tdef = map (\(_ ** tp) => print . generateDefs Haskell $ tp) (parseTNamed tdef)
-
-getInput : InputFile -> IO (Either FileError String)
-getInput (StringInput x) = pure (Right x)
-getInput (FileInput x) = readFile x
 
 writeOutput : OutputFile -> String -> IO ()
 writeOutput StdOutput tdef = putStrLn tdef
 writeOutput (FileOutput path) tdef = do Right () <- writeFile path tdef
                                           | Left error => putStrLn ("File write error: " ++ show path)
                                         putStrLn ("Generated typedef at " ++ path)
+getInput : InputFile -> IO (Either FileError String)
+getInput (StringInput x) = pure (Right x)
+getInput (FileInput x) = readFile x
+
+generateTDef : String -> Maybe String
+generateTDef tdef = map (\(_ ** tp) => print . generateDefs Haskell $ tp) (parseTNamed tdef)
+
 runWithOptions : TypedefOpts -> IO ()
 runWithOptions (MkTypedefOpts input output) = do
   Right typedef <- getInput input

--- a/parser/Parser.idr
+++ b/parser/Parser.idr
@@ -4,11 +4,116 @@ import Backend
 import Backend.Utils
 import Backend.Haskell
 
+import Options.Applicative
+
+%default total
+
+flag' : a -> (Option FlagParams a -> Option FlagParams a) -> Parser a
+flag' d f = OptP (f $ Opt defProps (FlagReader [] d))
+
+
+data InputFile = StringInput String
+               | FileInput String
+
+Show InputFile where
+  show StringInput = "command line input"
+  show (FileInput str) = str
+
+data OutputFile = StdOutput
+                | FileOutput String
+
+Show OutputFile where
+  show StdOutput = "stdout"
+  show (FileOutput str) = str
+
+stringInput : Parser InputFile
+stringInput = StringInput <$> strOption (long "inline" . short 'i')
+
+fileInput : Parser InputFile
+fileInput = FileInput <$> strOption (long "source" . short 's')
+
+parseInput : Parser InputFile
+parseInput = stringInput <|> fileInput
+
+stdOutput : Parser OutputFile
+stdOutput = flag' StdOutput (long "stdout")
+
+fileOutput : Parser OutputFile
+fileOutput = FileOutput <$> strOption (long "dest" . short 'd')
+
+parseOutput : Parser OutputFile
+parseOutput = fileOutput <|> stdOutput <|> pure StdOutput
+
+record TypedefOpts where
+  constructor MkTypedefOpts
+  input : InputFile
+  output : OutputFile
+
+
+Show TypedefOpts where
+  show (MkTypedefOpts i o) = "input : " ++ show i ++ "output : " ++ show o
+
+helpMessage : String
+helpMessage = """
+Welcome to Typedefs, programming language for types.
+
+Usage:
+  typdefs_parser (-i INLINE_TDEF | -s SOURCE) [-d DEST | --stdout]
+
+  --source, -s : path to the input file
+    example:
+      typedefs_parser -s bool.tdef
+
+  --inline, -i : input as a string inline
+    example:
+      typedefs_parser -i "(name bool (+ 1 1))" --stdout
+
+  --dest, -d : path to the destination file
+    example:
+      typedefs_parser -i bool.tdef project/typedefs/types.hs
+
+  --stdout : print the output on stdout
+    example:
+      typedefs_parser -i bool.tdef --stdout | grep "bool"
+"""
+
+parseOptions : Parser TypedefOpts
+parseOptions = MkTypedefOpts <$> parseInput <*> parseOutput
+
+
+processArgs : List String -> Either ParseError TypedefOpts
+processArgs (_ :: opts) = runParserFully parseOptions opts
+processArgs _ = Left (ErrorMsg helpMessage)
+
+
+
+generateTDef : String -> Maybe String
+generateTDef tdef = map (\(_ ** tp) => print . generateDefs Haskell $ tp) (parseTNamed tdef)
+
+getInput : InputFile -> IO (Either FileError String)
+getInput (StringInput x) = pure (Right x)
+getInput (FileInput x) = readFile x
+
+writeOutput : OutputFile -> String -> IO ()
+writeOutput StdOutput tdef = putStrLn tdef
+writeOutput (FileOutput path) tdef = do Right () <- writeFile path tdef
+                                          | Left error => putStrLn ("File write error: " ++ show path)
+                                        putStrLn ("Generated typedef at " ++ path)
+runWithOptions : TypedefOpts -> IO ()
+runWithOptions (MkTypedefOpts input output) = do
+  Right typedef <- getInput input
+    | Left err => putStrLn ("Filesystem error: " ++ show err)
+  case generateTDef typedef of
+       Nothing => putStrLn ("Typedef error: " ++ "could not generate typedef")
+       Just tdef => writeOutput output tdef
+
+--          let tpm = parseTNamed str
+--          putStrLn $ "parsed typedef: "
+--          putStrLn $ maybe ("Failed to parse '" ++ str ++ "'.") (\tp => show $ DPair.snd tp) tpm
+--          putStrLn $ ""
+--          putStrLn $ "haskell type: " ++ maybe ("Failed to parse '" ++ str ++ "'.") (\tp => print . generateDefs Haskell $ DPair.snd tp) tpm
+
+partial
 main : IO ()
-main = do
-  [_, str] <- getArgs
-  let tpm = parseTNamed str
-  putStrLn $ "parsed typedef: "
-  putStrLn $ maybe ("Failed to parse '" ++ str ++ "'.") (\tp => show $ DPair.snd tp) tpm
-  putStrLn $ ""
-  putStrLn $ "haskell type: " ++ maybe ("Failed to parse '" ++ str ++ "'.") (\tp => print . generateDefs Haskell $ DPair.snd tp) tpm
+main = processArgs <$> getArgs
+           >>= either (\(ErrorMsg msg) => putStrLn msg) runWithOptions

--- a/parser/Parser.idr
+++ b/parser/Parser.idr
@@ -21,14 +21,14 @@ getInput : InputFile -> IO (Either FileError String)
 getInput (StringInput x) = pure (Right x)
 getInput (FileInput x) = readFile x
 
-generateTDef : String -> Maybe String
-generateTDef tdef = map (\(_ ** tp) => print . generateDefs Haskell $ tp) (parseTNamed tdef)
+parseAndGenerateTDef : String -> Maybe String
+parseAndGenerateTDef tdef = map (\(_ ** tp) => print . generateDefs Haskell $ tp) (parseTNamed tdef)
 
 runWithOptions : TypedefOpts -> IO ()
 runWithOptions (MkTypedefOpts input output) = do
   Right typedef <- getInput input
     | Left err => putStrLn ("Filesystem error: " ++ show err)
-  case generateTDef typedef of
+  case parseAndGenerateTDef typedef of
        Nothing => putStrLn ("Typedef error: " ++ "could not generate typedef")
        Just tdef => writeOutput output tdef
 

--- a/typedefs-examples.nix
+++ b/typedefs-examples.nix
@@ -1,17 +1,11 @@
-{ stdenv, pkgs, idrisPackages }:
+{ build-idris-package, typedefs }:
 
-let
-  typedefs = pkgs.callPackage ./typedefs.nix { };
-in
-
-idrisPackages.build-idris-package {
+build-idris-package {
   name = "typedefs-examples";
   version = "dev";
   src = ./.;
 
-  idrisDeps = with idrisPackages; [
-    typedefs
-  ];
+  idrisDeps = [ typedefs ];
 
   postInstall = ''
     install -D typedefs_examples $out/bin/typedefs-examples

--- a/typedefs-parser-js.nix
+++ b/typedefs-parser-js.nix
@@ -1,18 +1,11 @@
-{ stdenv, pkgs, idrisPackages }:
+{ build-idris-package, typedefs , js }:
 
-let
-  typedefs = pkgs.callPackage ./typedefs.nix { };
-in
-
-idrisPackages.build-idris-package {
+build-idris-package {
   name = "typedefs-parser-js";
   version = "dev";
   src = ./.;
 
-  idrisDeps = with idrisPackages; [
-    typedefs
-    js
-  ];
+  idrisDeps = [ typedefs js ];
 
   postInstall = ''
     install -D typedefs_parser.js $out/share/typedefs/js/typedefs-parser.js

--- a/typedefs-parser.ipkg
+++ b/typedefs-parser.ipkg
@@ -6,4 +6,4 @@ main = Parser
 
 sourcedir = parser
 
-pkgs = typedefs
+pkgs = typedefs, optparse

--- a/typedefs-parser.nix
+++ b/typedefs-parser.nix
@@ -11,6 +11,7 @@ idrisPackages.build-idris-package {
 
   idrisDeps = with idrisPackages; [
     typedefs
+  , optparse
   ];
 
   postInstall = ''

--- a/typedefs-parser.nix
+++ b/typedefs-parser.nix
@@ -1,18 +1,11 @@
-{ stdenv, pkgs, idrisPackages }:
+{ build-idris-package, typedefs, optparse, }:
 
-let
-  typedefs = pkgs.callPackage ./typedefs.nix { };
-in
-
-idrisPackages.build-idris-package {
+build-idris-package {
   name = "typedefs-parser";
   version = "dev";
   src = ./.;
 
-  idrisDeps = with idrisPackages; [
-    typedefs
-  , optparse
-  ];
+  idrisDeps = [ typedefs optparse ];
 
   postInstall = ''
     install -D typedefs_parser $out/bin/typedefs-parser

--- a/typedefs.nix
+++ b/typedefs.nix
@@ -1,12 +1,16 @@
-{ stdenv, pkgs, idrisPackages }:
+{ build-idris-package
+, contrib
+, tparsec
+, specdris
+, bytes }:
 
-idrisPackages.build-idris-package {
+build-idris-package {
   name = "typedefs";
   version = "dev";
   src = ./.;
   doCheck = true;
 
-  idrisDeps = with idrisPackages; [
+  idrisDeps = [
     contrib
     tparsec
     specdris


### PR DESCRIPTION
fix #140 by adding `--help` and options for input and output files to typedef_parser

## caveats

This uses https://github.com/HuwCampbell/optparse-idris which has a mistake in how it runs the parser. I've used modified version of the library and will submit a pull request later.