### PR TITLE
WIP - Expose terms and type signatures in JS

### DIFF
--- a/parser.js/ParserJS.idr
+++ b/parser.js/ParserJS.idr
@@ -13,24 +13,21 @@ generateCode : String -> (n ** TNamed n) -> String
 generateCode "haskell"  (n  **tn) = toString $ generateDefs Haskell tn
 generateCode _          _         = "<error : unsupported backend>"
 
--- re-exports
-parseType : String -> Maybe (n : Nat ** TNamed n)
-parseType = parseTNamed 
 
-generateSerializers : String -> String -> Maybe String
-generateSerializers backend tdef = map (generateCode backend) (parseType tdef)
+generateTermSerializers : String -> String -> Maybe String
+generateTermSerializers backend tdef = map (generateCode backend) (parseTNamed tdef)
 
-genType : String -> (n ** TNamed n) -> String
-genType "reasonml" (n   ** tn) = toString $ generateDefs ReasonML tn
-genType "json"     (Z   ** tn) = toString $ generate JSONDef tn
-genType "json"     (S _ ** tn) = "<error : cannot generate JSON schema for open typedefs>"
-genType _          _           = "<error : unsupported backend>"
-
-generateTypeSignature : String -> String -> Maybe String
-generateTypeSignature backend tdef = map (genType backend) (parseType tdef)
+generateType : String -> String -> Maybe String
+generateType backend tdef = map (genType backend) (parseTNamed tdef)
+  where
+    genType : String -> (n ** TNamed n) -> String
+    genType "reasonml" (n   ** tn) = toString $ generateDefs ReasonML tn
+    genType "json"     (Z   ** tn) = toString $ generate JSONDef tn
+    genType "json"     (S _ ** tn) = "<error : cannot generate JSON schema for open typedefs>"
+    genType _          _           = "<error : unsupported backend>"
 
 lib : FFI_Export FFI_JS "" []
 lib = Data (Maybe String) "MaybeString" $
-      Fun generateSerializers "generateSerializers" $
-      Fun generateTypeSignature "generateTypeSignature" $
+      Fun generateTermSerializers "generateTermSerializers" $
+      Fun Main.generateType "generateType" $
       End

--- a/parser.js/ParserJS.idr
+++ b/parser.js/ParserJS.idr
@@ -23,7 +23,7 @@ generateSerializers backend tdef = map (generateCode backend) (parseType tdef)
 genType : String -> (n ** TNamed n) -> String
 genType "reasonml" (n   ** tn) = toString $ generateDefs ReasonML tn
 genType "json"     (Z   ** tn) = toString $ generate JSONDef tn
-genType "json"     (S _ ** tn) = "<error : cannot generte JSON schema for open typedefs>"
+genType "json"     (S _ ** tn) = "<error : cannot generate JSON schema for open typedefs>"
 genType _          _           = "<error : unsupported backend>"
 
 generateTypeSignature : String -> String -> Maybe String


### PR DESCRIPTION
fix #130 

I've split up the API between generating types and generating seralizers for terms that inhabit those types. I would like to clean up the typeclasses that expose this api to have a clear distiniction between generating the type signatures and generating the serializers. What do you think?

@epost could you take a look and try it?

I've also simplified the API so that we only ever interact with strings an no sigma types.