### PR TITLE
Index free syntax

### DIFF
--- a/src/Typedefs/Syntax.idr
+++ b/src/Typedefs/Syntax.idr
@@ -1,0 +1,30 @@
+module Typedefs.Syntax
+
+import Typedefs.Typedefs
+import Typedefs.Backend.Specialisation
+
+import Data.NEList
+
+
+data SyntaxDef = Zero 
+               | One
+               | Plus (List SyntaxDef)
+               | Times (List SyntaxDef)
+               | Constructor (List (String, SyntaxDef))
+               | App String (List SyntaxDef)
+               | Identifier String
+
+record TopLevelDef where
+  constructor MkTopLevelDef
+  Name : String
+  Variables : List String
+  Def : SyntaxDef
+
+toTDef : SyntaxDef -> Maybe (n ** TDef n)
+toTDef Zero = Just (0 ** T0)
+toTDef One = Just (0 ** T1)
+toTDef (Plus xs) = let s = traverse toTDef xs in ?whatSUm
+toTDef (Times xs) = ?watProd -- TProd <$> map toTDef xs
+toTDef (Constructor x) = ?watMu -- TMu <$> map ?thing x
+toTDef (App n xs) = let s = traverse toTDef xs in ?whut
+toTDef (Identifier x) = ?toTDef_rhs_7

--- a/src/Typedefs/Syntax.idr
+++ b/src/Typedefs/Syntax.idr
@@ -4,9 +4,9 @@ import Typedefs.Typedefs
 import Typedefs.Backend.Specialisation
 
 import Data.NEList
+import Data.Vect
 
-
-data SyntaxDef = Zero 
+data SyntaxDef = Zero
                | One
                | Plus (List SyntaxDef)
                | Times (List SyntaxDef)
@@ -23,8 +23,10 @@ record TopLevelDef where
 toTDef : SyntaxDef -> Maybe (n ** TDef n)
 toTDef Zero = Just (0 ** T0)
 toTDef One = Just (0 ** T1)
-toTDef (Plus xs) = let s = traverse toTDef xs in ?whatSUm
+toTDef (Plus (x :: y :: xs)) = do (n ** defs) <- traverse toTDef (fromList $ x :: y :: xs)
+                                  pure $ TSum defs
 toTDef (Times xs) = ?watProd -- TProd <$> map toTDef xs
 toTDef (Constructor x) = ?watMu -- TMu <$> map ?thing x
 toTDef (App n xs) = let s = traverse toTDef xs in ?whut
 toTDef (Identifier x) = ?toTDef_rhs_7
+toTDef _ = Nothing

--- a/src/Typedefs/Syntax/AST.idr
+++ b/src/Typedefs/Syntax/AST.idr
@@ -1,0 +1,23 @@
+module Typedefs.Syntax.AST
+
+%access public export
+
+data AnonymousDef = Zero | One
+                         | Sum AnonymousDef AnonymousDef
+                         | Prod AnonymousDef AnonymousDef
+                         | Ref String
+
+record DefName where
+  constructor MkDefName
+  name : String
+  arguments : List String
+
+data Definition
+  = Simple AnonymousDef
+  | Enum (List (String, AnonymousDef))
+  | Record (List (String, AnonymousDef))
+
+record TopLevelDef where
+  constructor MkTopLevelDef
+  name : DefName
+  def : Definition

--- a/src/Typedefs/Syntax/AST.idr
+++ b/src/Typedefs/Syntax/AST.idr
@@ -2,22 +2,38 @@ module Typedefs.Syntax.AST
 
 %access public export
 
-data AnonymousDef = Zero | One
-                         | Sum AnonymousDef AnonymousDef
-                         | Prod AnonymousDef AnonymousDef
-                         | Ref String
+mutual
+  data Expr = EEmb Term
+            | ESum Expr Term
+            | Ref String
+
+  -- Weak priority
+  data Term : Type where
+    TEmb : Factor -> Term
+    TMul : Term -> Factor -> Term
+
+  -- Strong priority
+  data Factor : Type where
+    FEmb : Power -> Factor
+    FPow : Factor -> Power -> Factor
+
+  -- Strongest priority
+  data Power : Type where
+    PLit : Nat -> Power
+    PEmb : Factor -> Power
+
 
 record DefName where
   constructor MkDefName
-  name : String
+  name      : String
   arguments : List String
 
 data Definition
-  = Simple AnonymousDef
-  | Enum (List (String, AnonymousDef))
-  | Record (List (String, AnonymousDef))
+  = Simple Expr
+  | Enum   (List (String, Expr))
+  | Record (List (String, Expr))
 
 record TopLevelDef where
   constructor MkTopLevelDef
   name : DefName
-  def : Definition
+  def  : Definition

--- a/src/Typedefs/Syntax/AST.idr
+++ b/src/Typedefs/Syntax/AST.idr
@@ -20,7 +20,7 @@ mutual
   -- Strongest priority
   data Power : Type where
     PLit : Nat -> Power
-    PEmb : Factor -> Power
+    PEmb : Expr -> Power
 
 
 record DefName where

--- a/src/Typedefs/Syntax/IndexFree.idr
+++ b/src/Typedefs/Syntax/IndexFree.idr
@@ -1,0 +1,57 @@
+module Typedefs.Syntax.IndexFree
+
+import Typedefs.Syntax.AST
+import TParsec
+import Data.NEList
+
+separator : (Alternative mn, Monad mn) =>
+            All (Parser mn p s :-> Parser mn p a :-> Parser mn p b :-> Parser mn p (a, b))
+separator sep a b = a `and` (sep `rand` b)
+
+-- this should be in tparsec
+sepBy : (Alternative mn, Monad mn) =>
+        All (Parser mn p a :-> Parser mn p s :-> Parser mn p (NEList a))
+sepBy parser sep = map (flip MkNEList []) parser
+             `alt` map (uncurry MkNEList) (parser `and` (map NEList.toList $ nelist (sep `rand` parser)))
+
+Parser' : Type -> Nat -> Type
+Parser' = Parser (TParsecT () Void Maybe) chars
+
+parseNoArg : All (Parser' DefName)
+parseNoArg = map (flip MkDefName []) alphas
+
+parseWithArgs : All (Parser' DefName)
+parseWithArgs =  map (uncurry MkDefName) $ alphas `and` (map NEList.toList $ nelist alphas)
+
+parseDefName : All (Parser' DefName)
+parseDefName = parseNoArg `alt` parseWithArgs
+
+parseAnon : All (Parser' AnonymousDef)
+
+nameColType : All (Parser' (String, AnonymousDef))
+nameColType = separator (char ':') alphas parseAnon
+
+parseSimple : All (Parser' Definition)
+parseSimple = map Simple parseAnon
+
+parseEnum : All (Parser' Definition)
+parseEnum = map (Enum . NEList.toList) $ nameColType `sepBy` char '|'
+
+parseRecord : All (Parser' Definition)
+parseRecord = between (char '{') (char '}') $
+              map (Record . NEList.toList) $ nameColType `sepBy` char ','
+
+
+parseDef : All (Parser' Definition)
+parseDef = alts
+  [ parseSimple
+  , parseEnum
+  , parseRecord
+  ]
+
+parseTopDef : All (Parser' TopLevelDef)
+parseTopDef = map (uncurry MkTopLevelDef) $ separator (string ":=") parseDefName parseDef
+
+parseDefinitions : All (Parser' (NEList TopLevelDef))
+parseDefinitions = nelist parseTopDef
+

--- a/typedefs-core.ipkg
+++ b/typedefs-core.ipkg
@@ -12,6 +12,7 @@ modules = Typedefs.Names
         , Typedefs.Backend.Haskell
         , Typedefs.Backend.JSON
         , Typedefs.Backend.ReasonML
+        , Typedefs.Syntax.Compiler
 
         , Typedefs.Test
         , Typedefs.Test.TypedefsSuite


### PR DESCRIPTION
This PR add support for a new index-free syntax which more closely resembles ml-style languages with data constructors:

```
List a := nil : 1 | cons : a * List a
```