### PR TITLE
Add AlphaTy, BetaTy and GammaTy

### DIFF
--- a/src/Typedefs/Library.idr
+++ b/src/Typedefs/Library.idr
@@ -61,3 +61,8 @@ TLeft = Inn . Left
 
 TRight : b -> Ty [a,b] TEither
 TRight = Inn . Right
+
+-- PAIR
+
+TPair : TDefR 2
+TPair = TProd [TVar 0, TVar 1]

--- a/src/Typedefs/Test/IdrisReferences.idr
+++ b/src/Typedefs/Test/IdrisReferences.idr
@@ -1,0 +1,30 @@
+module Typedefs.Test.IdrisReferences
+
+import Data.Vect
+import Typedefs.Typedefs
+import Typedefs.Library
+
+Var0 : TDefR 1
+Var0 = RRef 0
+
+||| Replacing reference
+instanceLists : (GammaTy [(1 ** List)] Var0) Nat
+instanceLists = [1,2,3]
+
+||| Replacing regerence with 2-argument constructor
+instanceEither : (GammaTy [(2 ** Either)] Var0) Nat String
+instanceEither = Right "test"
+
+||| Replacing 2-arguments variable with two 1-argument constructor
+instancePair : (GammaTy [(1 ** List), (1 ** List)] TPair) String Nat
+instancePair = (["this", "is", "a", "test"], [1,2,3])
+
+||| instanciating 1-argument constructor with 1-argument constructor
+instanceMaybe : (GammaTy [(1 ** List)] TMaybe) Nat
+instanceMaybe = Inn (Right [3])
+
+||| Instance 1-argument constructor with reference
+instanceRef : (GammaTy [(2 ** Either)] (TMaybe `ap` [Var0])) Nat String
+instanceRef = Inn (Right (Right "hello"))
+
+

--- a/typedefs-core.ipkg
+++ b/typedefs-core.ipkg
@@ -27,6 +27,7 @@ modules = Typedefs.Names
         , Typedefs.Test.ParseTests
         , Typedefs.Test.ReasonMLTests
         , Typedefs.Test.TermParseWriteTests
+        , Typedefs.Test.IdrisReferences
 
 tests = Typedefs.Test.TypedefsSuite.testSuite
 


### PR DESCRIPTION
fix #215 

Those functions allow to either partially apply a TDef with its
Idris Type representation or use a type constructor to fill one of
its holes.