### PR TITLE
Rewrite TermParse using specialisation context

### DIFF
--- a/examples/Examples.idr
+++ b/examples/Examples.idr
@@ -110,7 +110,7 @@ nestedMu : TNamedR 0
 nestedMu = TName "Foo" $ TMu [("Bar", nat1)]
 
 serializeTest : String
-serializeTest = serialize [Int] [show] Main.maybe (Main.just Int 6)
+serializeTest = serialize [show] Main.maybe (Main.just Int 6)
 
 main : IO ()
 main = putStrLn $ showTDef (def Main.list)

--- a/examples/Examples.idr
+++ b/examples/Examples.idr
@@ -109,8 +109,8 @@ listNullBit = (def list) `ap` [nullBit]
 nestedMu : TNamedR 0
 nestedMu = TName "Foo" $ TMu [("Bar", nat1)]
 
-serializeTest : String
-serializeTest = serialize [show] Main.maybe (Main.just Int 6)
+serialiseTest : String
+serialiseTest = serialise [] [show] Main.maybe (Main.just Int 6)
 
 main : IO ()
 main = putStrLn $ showTDef (def Main.list)

--- a/src/Typedefs/DependentLookup.idr
+++ b/src/Typedefs/DependentLookup.idr
@@ -1,0 +1,27 @@
+||| This module is by itself because its only function takes ages to compile
+module DependentLookup
+
+import Data.Vect
+
+%default total
+
+||| Lookup for maps with a shared index
+public export
+depLookup : DecEq t => {w : t} -> {f, g : t -> Type} -> DecEq (f w) =>
+             (vs : Vect n (v : t ** (f v, g v))) -> f w ->
+             Maybe (a : f w ** b : g w ** Elem (w ** (a, b)) vs)
+depLookup [] item = Nothing -- Not found
+depLookup ((n ** (key, val)) :: xs) item {w} with (decEq w n)
+  -- if indices don't match then values can't possibly match since they have different type
+  depLookup ((n ** (key, val)) :: xs) item {w = w} | (No contra) =
+    do (a ** b ** prf) <- depLookup xs item
+       pure (a ** b ** There prf)
+  depLookup ((n ** (key, val)) :: xs) item {w = n} | (Yes Refl) with (decEq key item)
+    depLookup ((n ** (item, val)) :: xs) item {w = n} | (Yes Refl) | (Yes Refl) =
+      -- Index and Value match, return
+      Just (item ** val ** Here {x=(n ** (item, val))})
+    depLookup ((n ** (key, val)) :: xs) item {w = n} | (Yes Refl) | (No contra) =
+      -- Index match but values differ
+      do (a ** b ** prf) <- depLookup xs item
+         pure (a ** b ** There prf)
+

--- a/src/Typedefs/Idris.idr
+++ b/src/Typedefs/Idris.idr
@@ -56,9 +56,9 @@ mutual
   ||| The replacement mapping can only replace types in Mu or App Position.
   ||| Products, Sums, 0, 1 and variables are never replaced.
   |||
-  ||| @rep : The mapping between TDefs and the specialised version as an Idris type
+  ||| @sp : The mapping between TDefs and the specialised version as an Idris type
   ||| @tvars : The list of types that will be used to fill all free variables
-  Ty' : (rep : SpecialList) -> (tvars : Vect n Type) ->  TDefR n -> Type
+  Ty' : (sp : SpecialList) -> (tvars : Vect n Type) ->  TDefR n -> Type
   Ty' sp tvars T0             = Void
   Ty' sp tvars T1             = Unit
   Ty' sp tvars (TSum xs) {n}  = Tnary' sp tvars xs Either

--- a/src/Typedefs/TermWrite.idr
+++ b/src/Typedefs/TermWrite.idr
@@ -1,6 +1,8 @@
 module Typedefs.TermWrite
 
 import Typedefs.Idris
+import Typedefs.DependentLookup
+import Typedefs.TypedefsDecEq
 import Typedefs.Names
 
 import Data.Vect
@@ -14,129 +16,218 @@ import Language.JSON
 
 -- serialization
 
-||| Builds a list that allows to create terms of the given type for each Type in the list of types
+
+||| A proof that each Type in the indexed list can be converted into the target type
 public export
 data HasGenericWriters : (target : Type) -> (types : Vect n Type) -> Type where
-  Nil : HasGenericWriters a Nil
-  (::) : (x -> a) -> HasGenericWriters a xs -> HasGenericWriters a (x :: xs)
+  Nil  : HasGenericWriters a Nil
+  (::) : (src -> trg) -> HasGenericWriters trg xs -> HasGenericWriters trg (src :: xs)
 
-public export
-interface TDefSerialiser target where
-  serialise : {n : Nat} -> {ts : Vect n Type} -> HasGenericWriters target ts ->
-              (td : TDefR n) -> Ty ts td -> target
+namespace SpecialisedWriters
+  ||| Prove that there exist a writer function for every type in the specialisation list
+  public export
+  data HasSpecialisedWriter : (target : Type) -> (specialised : SpecialList l) -> Type where
+    Nil  : HasSpecialisedWriter a []
+    (::) : {n : Nat} -> {def : TDefR n} -> {constr : TypeConstructor n} ->
+           ({args : Vect n Type} -> HasGenericWriters a args -> ApplyVect constr args -> a) ->
+           HasSpecialisedWriter a xs ->
+           HasSpecialisedWriter a ((n ** (def, constr)) :: xs)
 
-public export
-TDefSerialiser String where
-  serialise  ws        T1                    ()        = "()"
-  serialise  ws        (TSum [x,_])          (Left l)  =
-    parens $ "left "  ++ serialise ws x l
-  serialise  ws        (TSum [_,y])          (Right r) =
-    parens $ "right " ++ serialise ws y r
-  serialise  ws        (TSum (x::_::_::_))   (Left l)  =
-    parens $ "left "  ++ serialise ws x l
-  serialise  ws        (TSum (_::y::z::zs))  (Right r) =
-    parens $ "right " ++ serialise ws (TSum (y::z::zs)) r
-  serialise  ws        (TProd [x,y])         (a, b)    =
-    parens $ "both "  ++ serialise ws x a ++ " " ++ serialise ws y b
-  serialise  ws        (TProd (x::y::z::zs)) (a, b)    =
-    parens $ "both "  ++ serialise ws x a ++ " " ++ serialise ws (TProd (y::z::zs)) b
-  serialise {ts=(_::_)}    (w::_)    (RRef FZ)             x         = w x
-  serialise {ts=(_::_::_)} (_::w::_) (RRef (FS FZ))        x         = w x
-  serialise {ts=(_::ts)}   (_::ws)   (RRef (FS (FS i)))    x         = serialise {ts} ws (TVar (FS i)) x
-  serialise {ts=(_::_)}    (w::_)    (TVar FZ)             x         = w x
-  serialise {ts=(_::_::_)} (_::w::_) (TVar (FS FZ))        x         = w x
-  serialise {ts=(_::ts)}   (_::ws)   (TVar (FS (FS i)))    x         = serialise {ts} ws (TVar (FS i)) x
-  serialise ws        (TApp f ys)           x         =
-    assert_total $ serialise ws (ap (def f) ys) (convertTy' x)
-  serialise ws        (TMu td)              (Inn x) {ts} =
-    let inner = assert_total $ serialise {ts=(Mu ts (args td))::ts} (serialise ws (TMu td)::ws) (args td) x in
-        "(inn " ++ inner ++ ")"
+||| Lookup in the specialised context for the function that converts a special type to its target representation
+lookupTypeReplacement : {sp : SpecialList l} -> (e : Elem (n ** (td, constr)) sp) ->
+              {target : Type} ->
+              (sw : HasSpecialisedWriter target sp) ->
+              {args : Vect n Type} -> HasGenericWriters target args -> ApplyVect constr args -> target
+lookupTypeReplacement Here (s :: sp) = s
+lookupTypeReplacement (There e) (s :: sp) = lookupTypeReplacement e sp
 
--- Binary serialisation
-
-serializeInt : {n : Nat} -> (Fin n) -> Bytes
-serializeInt x = pack [prim__truncBigInt_B8 (finToInteger x)]
-
-injectionInv : (ts : Vect (2 + k) (TDefR n)) -> Tnary tvars ts Either -> (i : Fin (2 + k) ** Ty tvars (index i ts))
+||| Returns the index and the type of a sum from an array of TDefs
+injectionInv : (ts : Vect (2 + k) (TDefR n)) -> Tnary' sp tvars ts Either -> (i : Fin (2 + k) ** Ty' sp tvars (index i ts))
 injectionInv [a,b] (Left x) = (0 ** x)
 injectionInv [a,b] (Right y) = (1 ** y)
 injectionInv (a::b::c::tds) (Left x) = (0 ** x)
 injectionInv (a::b::c::tds) (Right y) =
   let (i' ** y') = injectionInv (b::c::tds) y in (FS i' ** y')
 
+getVariable : {ts : Vect (S n) Type} -> (i : Fin (S n)) -> (ws : HasGenericWriters target ts) -> index i ts -> target
+getVariable FZ (f :: z) x {ts = (y :: xs)} = f x
+getVariable (FS FZ) (_ :: f :: ws) x = f x
+getVariable (FS (FS y)) (w :: ws) x = getVariable (FS y) ws x
+
+||| Given a vector of TDef n and n types to fill its holes, return the vector of types correpondng to those tdefs
+FromTDefToTy : {n : Nat} -> SpecialList l -> Vect n Type -> Vect k (TDefR n) -> Vect k Type
+FromTDefToTy sp types vs = map (Ty' sp types) vs
+
+||| Magically generate the writers for a vector of TDefs in argument position
+|||
+||| For some reason this couldn't be placed in a where-clause inside `serialise`. The lookup for
+||| instances of `TDefSeraliser` would get confused and say that there aren't any suitable instances
+||| for `serialiser`. That's why we simply pass it as a partially applied function
+makeWriters : {target : Type} -> {sp : SpecialList l} ->
+               (tys : Vect n Type) ->
+               (spp : HasSpecialisedWriter target sp) ->
+               (gen : HasGenericWriters target tys) ->
+               ((tdef : TDefR n) -> Ty' sp tys tdef -> target) ->
+               (vs : Vect k (TDefR n)) ->
+               HasGenericWriters target (FromTDefToTy sp tys vs)
+makeWriters tys spp gen fn [] = []
+makeWriters tys spp gen fn (td :: tds) = (fn td) :: (makeWriters tys spp gen fn tds)
+
+public export
+interface TDefSerialiser target where
+  unitVal : target
+
+  ||| How to convert a sum into a term in the target type
+  foldSum : {ts : Vect n Type} -> {sp : SpecialList l} ->
+            HasSpecialisedWriter target sp ->
+            HasGenericWriters target ts ->
+            (args : Vect (2 + k) (TDefR n)) ->
+            Ty' sp ts (TSum args) -> target
+
+  ||| How to convert a prod into a term in the target type
+  foldProd : {ts : Vect n Type} -> {sp : SpecialList l} ->
+             HasSpecialisedWriter target sp ->
+             HasGenericWriters target ts ->
+             (args : Vect (2 + k) (TDefR n)) ->
+             Ty' sp ts (TProd args) -> target
+
+  ||| How to decorate a mu term
+  muPrefix : target -> target
+
+  ||| Convert an arbitrary TDef into a term in the target format
+  |||
+  ||| Given an arbitrary specialisation list, a proof that every specialised type has a writer
+  ||| and a proof that every type that will inhabit each type variable also has a writer, return
+  ||| a function that will take a Typedef and its Idris term and convert it into a term in the
+  ||| target format
+  ||| @n : The number of free variables in the Typedefs
+  ||| @ts : The vector of types that will inhabit the free variables
+  ||| @sp : The specialisation list of types that will be replaced by a specialised version
+  ||| @spp : A proof that every specialised constructor and its arguments have a writer
+  ||| @ws : A proof that every type parameter has a writer
+  serialise : {n : Nat} -> {ts : Vect n Type} -> {sp : SpecialList l} ->
+              (spp : HasSpecialisedWriter target sp) -> (ws : HasGenericWriters target ts) ->
+              (td : TDefR n) -> Ty' sp ts td -> target
+  serialise spp ws T1           x = unitVal
+  serialise spp ws (TSum args)  x = foldSum spp ws args x
+  serialise spp ws (TProd args) x = foldProd spp ws args x
+  serialise spp ws (RRef i)     x = getVariable i ws x
+  serialise spp ws (TVar i)     x = getVariable i ws x
+
+  -- first lookup the specialisation context
+  serialise spp {sp} {ts} {n} ws (TApp (TName _ def) ys) x with (depLookup sp def)
+    serialise spp {sp} {ts} {n} ws (TApp (TName _ def) ys) x | Nothing =
+
+      -- if there is nothing, proceed as is nothing changed
+      -- if we had a proof that no substitutions we performed we could remove the `believe_me`
+      assert_total $ serialise spp ws (def `ap` ys) (believe_me x)
+    serialise spp {sp} {ts} {n} ws (TApp (TName _ def) ys) x | (Just (d ** constr ** prf)) =
+
+      -- Otherwise, replace the type using the magic lookup.
+      -- This requires to pass a list of writer functions for the type arguments. Since the
+      -- type arguments come from the vector of TDefs passed in arguments to the TApp we
+      -- generate a new `HasGenericWriter` using `serialise` itself a writer function from
+      -- source type (each TDef in the argument vector) to the target type.
+      lookupTypeReplacement prf spp (makeWriters ts spp ws (assert_total $ serialise spp ws) ys) x
+
+  -- first lookup the specialisation context
+  serialise spp {sp} ws (TMu td) x {ts} with (depLookup sp (TMu td))
+    serialise spp ws (TMu td) (Inn x') {ts = ts} | Nothing =
+
+      -- if we didn't find anything we proceed as usual
+      -- if we had a proof that no substitutions we performed we could remove the `believe_me`
+      -- before returning we wrap the result in the `muPrefix` decorator
+      let inner = assert_total $ serialise spp {ts=(Mu ts (args td))::ts}
+                                           ((serialise [] ws (TMu td)) :: ws)
+                                           (args td)
+                                           (believe_me x')
+       in muPrefix inner
+    serialise spp ws (TMu td) x {ts = ts} | (Just (def ** constr ** prf)) =
+
+      -- Otherwise lookup the type to be replaced and apply it using the vector of types given
+      -- in the context
+      lookupTypeReplacement prf spp {args=ts} ws x
+
+---------------------------------------------------------------------------------------------
+-- Strings                                                                                 --
+---------------------------------------------------------------------------------------------
+
+public export
+TDefSerialiser String where
+
+  unitVal = "()"
+
+  foldSum sp ws ([x,_]) (Left l) =
+    parens $ "left "  ++ serialise sp ws x l
+  foldSum sp ws ([_,y]) (Right r) =
+    parens $ "right " ++ serialise sp ws y r
+  foldSum sp ws ((x::_::_::_)) (Left l) =
+    parens $ "left "  ++ serialise sp ws x l
+  foldSum sp ws ((_::y::z::zs)) (Right r) =
+    parens $ "right " ++ serialise sp ws (TSum (y::z::zs)) r
+
+  foldProd sp ws ([x,y]) (a, b) =
+    parens $ "both "  ++ serialise sp ws x a ++ " " ++ serialise sp ws y b
+  foldProd sp ws ((x::y::z::zs)) (a, b) =
+    parens $ "both "  ++ serialise sp ws x a ++ " " ++ serialise sp ws (TProd (y::z::zs)) b
+
+  muPrefix inner = "(inn " ++ inner ++ ")"
+
+---------------------------------------------------------------------------------------------
+-- Binary                                                                                  --
+---------------------------------------------------------------------------------------------
+
+serializeInt : {n : Nat} -> (Fin n) -> Bytes
+serializeInt x = pack [prim__truncBigInt_B8 (finToInteger x)]
+
 public export
 TDefSerialiser Bytes where
-  serialise ws T0 x impossible
-  serialise ws T1 x = empty
-  serialise ws (TSum {k = k} tds) x =
-     let (i ** x') = injectionInv tds x in
-     (serializeInt i) ++ (assert_total $ serialise ws (index i tds) x')
-  serialise ws (TProd [a, b]) (x, y) =
-    (serialise ws a x) ++ (serialise ws b y)
-  serialise ws (TProd (a::b::c::tds)) (x, y) =
-    (serialise ws a x) ++ (serialise ws (TProd (b::c::tds))) y
-  serialise {ts} ws (TMu tds) (Inn x) =
-    assert_total $ serialise {ts=(Mu ts (args tds))::ts}  (serialise ws (TMu tds)::ws) (args tds) x
-  serialise {ts=(t::ts)} (w::ws) (TVar FZ) x = w x
-  serialise {ts=(t::ts)} (w::ws) {n = S (S n')} (TVar (FS i)) x =
-    serialise ws {n = (S n')} (TVar i) x
-  serialise {ts=(t::ts)} (w::ws) (RRef FZ) x =  w x
-  serialise {ts=(t::ts)} (w::ws) {n = S (S n')} (RRef (FS i)) x =
-    serialise ws {n = (S n')} (RRef i) x
-  serialise {ts} ws (TApp (TName n d) xs) x =
-    assert_total $ serialise ws (ap d xs) (convertTy {n=n} {v=ts} {def=d} {xs=xs} x)
 
------------------
--- JSON        --
------------------
+  unitVal = empty
+
+  foldSum sp ws args tv =
+     let (i ** x') = injectionInv args tv in
+     (serializeInt i) ++ (assert_total $ serialise sp ws (index i args) x')
+
+  foldProd sp ws [a, b] (x, y) =
+    (serialise sp ws a x) ++ (serialise sp ws b y)
+  foldProd sp ws (a::b::c::tds) (x, y) =
+    (serialise sp ws a x) ++ (serialise sp ws (TProd (b::c::tds))) y
+
+  muPrefix = id
+
+---------------------------------------------------------------------------------------------
+-- JSON                                                                                    --
+---------------------------------------------------------------------------------------------
 
 
 makeFields : Nat -> List String
 makeFields n = map (("_" ++) . show) [0 .. n]
 
-mutual
-  serialiseJSONMu : HasGenericWriters JSON ts -> Mu ts td -> JSON
-  serialiseJSONMu ws {ts} {td} (Inn x) = JObject [("inn",
-    (assert_total $ serialiseJSON {ts=((Mu ts td)::ts)} ((serialiseJSONMu ws)::ws) td x))]
+public export
+TDefSerialiser JSON where
 
-  serialiseTNaryProd : HasGenericWriters JSON ts -> (defs: Vect (2 + k) (TDefR n))
-                -> Tnary ts defs Pair
-                -> List JSON -> List JSON
-  serialiseTNaryProd writers [x, y] (a, b) acc =
-    [serialiseJSON writers x a, serialiseJSON writers y b]
-  serialiseTNaryProd writers (x :: y :: z :: zs) (a , b) acc =
-    serialiseJSON writers x a :: serialiseTNaryProd writers (y :: z :: zs) b acc
-
-  serialiseJSON : HasGenericWriters JSON ts -> (t : TDefR n) -> Ty ts t -> JSON
-  -- Unit is an empty object
-  serialiseJSON x T1 tm = JObject []
+  unitVal = JObject []
 
   -- Products are serialised as { "_0" : a, "_1" : b, ... , "_x" : n } where the key stands for the
   -- index in the product
-  serialiseJSON x (TProd ls) tm = let res = serialiseTNaryProd x ls tm [] in
-                                      JObject (zip (makeFields (length ls)) res)
+  foldProd sp ws args tv =  let res = serialiseTNaryProd sp ws args tv in
+                            JObject (zip (makeFields (length args)) res)
+    where
+      serialiseTNaryProd : {sp : SpecialList l} ->
+                           HasSpecialisedWriter JSON sp -> HasGenericWriters JSON ts ->
+                           (defs: Vect (2 + k) (TDefR n)) ->
+                           Tnary' sp ts defs Pair -> List JSON
+      serialiseTNaryProd sp writers [x, y] (a, b) =
+        [serialise sp writers x a, serialise sp writers y b]
+      serialiseTNaryProd sp writers (x :: y :: z :: zs) (a , b) =
+        serialise sp writers x a :: serialiseTNaryProd sp writers (y :: z :: zs) b
+
+  -- Mus are identified by an obect with a single `inn` field
+  muPrefix inner =  JObject [("inn",  inner)]
+
   -- Sums are serialized as { "_x" : term } where x is the index in the sum
-  serialiseJSON x (TSum xs) tm =
-    let (i ** def) = injectionInv xs tm in
-        JObject [("_"++ show (toNat i), assert_total $ serialiseJSON x (index i xs) def)]
+  foldSum sp ws args tv =
+    let (i ** def) = injectionInv args tv in
+        JObject [("_"++ show (toNat i), assert_total $ serialise sp ws (index i args) def)]
 
-  -- Mu are serialised as { "inn" : rec } where rec is the sum associated with a constructor
-  serialiseJSON {ts} ws (TMu td) (Inn x) =
-      JObject [("inn",  assert_total $
-      serialiseJSON {ts=((Mu ts (args td))::ts)} ((serialiseJSONMu {td=args td} ws)::ws) (args td) x)]
-
-  -- TApp applies the tdef to its argument and then serialises the result
-  serialiseJSON ws (TApp f ys) tm =
-        assert_total $ serialiseJSON ws (ap (def f) ys) (convertTy' tm)
-
-  -- References and variables simply defer to the vector of writers
-  serialiseJSON (w::_)    (RRef FZ)          x = w x
-  serialiseJSON (_::w::_) (RRef (FS FZ))     x = w x
-  serialiseJSON (_::ws)   (RRef (FS (FS i))) x = serialiseJSON ws (RRef (FS i)) x
-  serialiseJSON (w::_)    (TVar FZ)          x = w x
-  serialiseJSON (_::w::_) (TVar (FS FZ))     x = w x
-  serialiseJSON (_::ws)   (TVar (FS (FS i))) x = serialiseJSON ws (TVar (FS i)) x
-
-public export
-TDefSerialiser JSON where
-  serialise = serialiseJSON

--- a/src/Typedefs/TermWrite.idr
+++ b/src/Typedefs/TermWrite.idr
@@ -1,6 +1,7 @@
 module Typedefs.TermWrite
 
 import Typedefs.Idris
+import Typedefs.Names
 
 import Data.Vect
 
@@ -10,54 +11,50 @@ import Data.ByteArray
 import Language.JSON
 
 %default total
-%access public export
 
 -- serialization
 
 ||| Builds a list that allows to create terms of the given type for each Type in the list of types
+public export
 data HasGenericWriters : (target : Type) -> (types : Vect n Type) -> Type where
   Nil : HasGenericWriters a Nil
-  (::) : {xs : Vect n Type} -> (x -> a) -> HasGenericWriters a xs -> HasGenericWriters a (x :: xs)
+  (::) : (x -> a) -> HasGenericWriters a xs -> HasGenericWriters a (x :: xs)
 
-mutual
-  serializeMu : (ts : Vect n Type) -> HasGenericWriters String ts -> Mu ts td -> String
-  serializeMu ts ws {td} (Inn x) = parens $ "inn " ++
-    (assert_total $ serialize ((Mu ts td)::ts) ((serializeMu {td} ts ws)::ws) td x)
+public export
+interface TDefSerialiser target where
+  serialise : {n : Nat} -> {ts : Vect n Type} -> HasGenericWriters target ts ->
+              (td : TDefR n) -> Ty ts td -> target
 
-  serialize : (ts : Vect n Type) -> HasGenericWriters String ts
-           -> (t : TDefR n) -> (tm : Ty ts t) -> String
-  serialize  ts       ws        T1                    ()        = "()"
-  serialize  ts       ws        (TSum [x,_])          (Left l)  =
-    parens $ "left "  ++ serialize ts ws x l
-  serialize  ts       ws        (TSum [_,y])          (Right r) =
-    parens $ "right " ++ serialize ts ws y r
-  serialize  ts       ws        (TSum (x::_::_::_))   (Left l)  =
-    parens $ "left "  ++ serialize ts ws x l
-  serialize  ts       ws        (TSum (_::y::z::zs))  (Right r) =
-    parens $ "right " ++ serialize ts ws (TSum (y::z::zs)) r
-  serialize  ts       ws        (TProd [x,y])         (a, b)    =
-    parens $ "both "  ++ serialize ts ws x a ++ " " ++ serialize ts ws y b
-  serialize  ts       ws        (TProd (x::y::z::zs)) (a, b)    =
-    parens $ "both "  ++ serialize ts ws x a ++ " " ++ serialize ts ws (TProd (y::z::zs)) b
-  serialize (_::_)    (w::_)    (RRef FZ)             x         = w x
-  serialize (_::_::_) (_::w::_) (RRef (FS FZ))        x         = w x
-  serialize (_::ts)   (_::ws)   (RRef (FS (FS i)))    x         = serialize ts ws (TVar (FS i)) x
-  serialize (_::_)    (w::_)    (TVar FZ)             x         = w x
-  serialize (_::_::_) (_::w::_) (TVar (FS FZ))        x         = w x
-  serialize (_::ts)   (_::ws)   (TVar (FS (FS i)))    x         = serialize ts ws (TVar (FS i)) x
-  serialize ts        ws        (TApp f ys)           x         =
-    assert_total $ serialize ts ws (ap (def f) ys) (convertTy' x)
-  serialize ts        ws        (TMu td)              (Inn x)   =
-    "(inn " ++
-      serialize ((Mu ts (args td))::ts) ((serializeMu {td=args td} ts ws)::ws) (args td) x
-      ++ ")"
+public export
+TDefSerialiser String where
+  serialise  ws        T1                    ()        = "()"
+  serialise  ws        (TSum [x,_])          (Left l)  =
+    parens $ "left "  ++ serialise ws x l
+  serialise  ws        (TSum [_,y])          (Right r) =
+    parens $ "right " ++ serialise ws y r
+  serialise  ws        (TSum (x::_::_::_))   (Left l)  =
+    parens $ "left "  ++ serialise ws x l
+  serialise  ws        (TSum (_::y::z::zs))  (Right r) =
+    parens $ "right " ++ serialise ws (TSum (y::z::zs)) r
+  serialise  ws        (TProd [x,y])         (a, b)    =
+    parens $ "both "  ++ serialise ws x a ++ " " ++ serialise ws y b
+  serialise  ws        (TProd (x::y::z::zs)) (a, b)    =
+    parens $ "both "  ++ serialise ws x a ++ " " ++ serialise ws (TProd (y::z::zs)) b
+  serialise {ts=(_::_)}    (w::_)    (RRef FZ)             x         = w x
+  serialise {ts=(_::_::_)} (_::w::_) (RRef (FS FZ))        x         = w x
+  serialise {ts=(_::ts)}   (_::ws)   (RRef (FS (FS i)))    x         = serialise {ts} ws (TVar (FS i)) x
+  serialise {ts=(_::_)}    (w::_)    (TVar FZ)             x         = w x
+  serialise {ts=(_::_::_)} (_::w::_) (TVar (FS FZ))        x         = w x
+  serialise {ts=(_::ts)}   (_::ws)   (TVar (FS (FS i)))    x         = serialise {ts} ws (TVar (FS i)) x
+  serialise ws        (TApp f ys)           x         =
+    assert_total $ serialise ws (ap (def f) ys) (convertTy' x)
+  serialise ws        (TMu td)              (Inn x) {ts} =
+    let inner = assert_total $ serialise {ts=(Mu ts (args td))::ts} (serialise ws (TMu td)::ws) (args td) x in
+        "(inn " ++ inner ++ ")"
 
 -- Binary serialisation
 
-Serialiser : Type -> Type
-Serialiser a = a -> Bytes
-
-serializeInt : {n : Nat} -> Serialiser (Fin n)
+serializeInt : {n : Nat} -> (Fin n) -> Bytes
 serializeInt x = pack [prim__truncBigInt_B8 (finToInteger x)]
 
 injectionInv : (ts : Vect (2 + k) (TDefR n)) -> Tnary tvars ts Either -> (i : Fin (2 + k) ** Ty tvars (index i ts))
@@ -67,78 +64,79 @@ injectionInv (a::b::c::tds) (Left x) = (0 ** x)
 injectionInv (a::b::c::tds) (Right y) =
   let (i' ** y') = injectionInv (b::c::tds) y in (FS i' ** y')
 
-serializeBinary : (t : TDefR n) -> (ts : Vect n (a ** Serialiser a)) ->
-                  Serialiser (Ty (map DPair.fst ts) t)
-serializeBinary T0 ts x impossible
-serializeBinary T1 ts x = empty
-serializeBinary (TSum {k = k} tds) ts x =
-   let (i ** x') = injectionInv tds x in
-   (serializeInt i) ++ (assert_total $ serializeBinary (index i tds) ts x')
-serializeBinary (TProd [a, b]) ts (x, y) =
-  (serializeBinary a ts x) ++ (serializeBinary b ts y)
-serializeBinary (TProd (a::b::c::tds)) ts (x, y) =
-  (serializeBinary a ts x) ++ (serializeBinary (TProd (b::c::tds))) ts y
-serializeBinary (TMu tds) ts (Inn x) =
-  assert_total $  serializeBinary (args tds) ((Mu (map DPair.fst ts) (args tds) ** serializeBinary (TMu tds) ts)::ts) x
-serializeBinary (TVar FZ) (t::ts) x = snd t x
-serializeBinary {n = S (S n')} (TVar (FS i)) (t::ts) x =
-  serializeBinary {n = (S n')} (TVar i) ts x
-serializeBinary (RRef FZ) (t::ts) x = snd t x
-serializeBinary {n = S (S n')} (RRef (FS i)) (t::ts) x =
-  serializeBinary {n = (S n')} (RRef i) ts x
-serializeBinary (TApp (TName n d) xs) ts x =
-  assert_total $ serializeBinary (ap d xs) ts (convertTy {n=n} {v=map DPair.fst ts} {def=d} {xs=xs} x)
+public export
+TDefSerialiser Bytes where
+  serialise ws T0 x impossible
+  serialise ws T1 x = empty
+  serialise ws (TSum {k = k} tds) x =
+     let (i ** x') = injectionInv tds x in
+     (serializeInt i) ++ (assert_total $ serialise ws (index i tds) x')
+  serialise ws (TProd [a, b]) (x, y) =
+    (serialise ws a x) ++ (serialise ws b y)
+  serialise ws (TProd (a::b::c::tds)) (x, y) =
+    (serialise ws a x) ++ (serialise ws (TProd (b::c::tds))) y
+  serialise {ts} ws (TMu tds) (Inn x) =
+    assert_total $ serialise {ts=(Mu ts (args tds))::ts}  (serialise ws (TMu tds)::ws) (args tds) x
+  serialise {ts=(t::ts)} (w::ws) (TVar FZ) x = w x
+  serialise {ts=(t::ts)} (w::ws) {n = S (S n')} (TVar (FS i)) x =
+    serialise ws {n = (S n')} (TVar i) x
+  serialise {ts=(t::ts)} (w::ws) (RRef FZ) x =  w x
+  serialise {ts=(t::ts)} (w::ws) {n = S (S n')} (RRef (FS i)) x =
+    serialise ws {n = (S n')} (RRef i) x
+  serialise {ts} ws (TApp (TName n d) xs) x =
+    assert_total $ serialise ws (ap d xs) (convertTy {n=n} {v=ts} {def=d} {xs=xs} x)
 
-serializeBinaryClosed : (t : TDefR 0) -> Serialiser (Ty [] t)
-serializeBinaryClosed t = serializeBinary t []
+-----------------
+-- JSON        --
+-----------------
 
-
-HasJSONWriters : Vect n Type -> Type
-HasJSONWriters = HasGenericWriters JSON
 
 makeFields : Nat -> List String
 makeFields n = map (("_" ++) . show) [0 .. n]
 
 mutual
-  serialiseJSONMu : (ts : Vect n Type) -> HasJSONWriters ts -> Mu ts td -> JSON
-  serialiseJSONMu ts ws {td} (Inn x) = JObject [("inn",
-    (assert_total $ serialiseJSON ((Mu ts td)::ts) ((serialiseJSONMu {td} ts ws)::ws) td x))]
+  serialiseJSONMu : HasGenericWriters JSON ts -> Mu ts td -> JSON
+  serialiseJSONMu ws {ts} {td} (Inn x) = JObject [("inn",
+    (assert_total $ serialiseJSON {ts=((Mu ts td)::ts)} ((serialiseJSONMu ws)::ws) td x))]
 
-  serialiseTNaryProd : (ts : Vect n Type) -> HasJSONWriters ts -> (defs: Vect (2 + k) (TDefR n))
+  serialiseTNaryProd : HasGenericWriters JSON ts -> (defs: Vect (2 + k) (TDefR n))
                 -> Tnary ts defs Pair
                 -> List JSON -> List JSON
-  serialiseTNaryProd types writers [x, y] (a, b) acc =
-    [serialiseJSON types writers x a, serialiseJSON types writers y b]
-  serialiseTNaryProd types writers (x :: y :: z :: zs) (a , b) acc =
-    serialiseJSON types writers x a :: serialiseTNaryProd types writers (y :: z :: zs) b acc
+  serialiseTNaryProd writers [x, y] (a, b) acc =
+    [serialiseJSON writers x a, serialiseJSON writers y b]
+  serialiseTNaryProd writers (x :: y :: z :: zs) (a , b) acc =
+    serialiseJSON writers x a :: serialiseTNaryProd writers (y :: z :: zs) b acc
 
-  serialiseJSON : (ts : Vect n Type) -> HasJSONWriters ts ->
-                  (t : TDefR n) -> (tm : Ty ts t) -> JSON
+  serialiseJSON : HasGenericWriters JSON ts -> (t : TDefR n) -> Ty ts t -> JSON
   -- Unit is an empty object
-  serialiseJSON ts x T1 tm = JObject []
+  serialiseJSON x T1 tm = JObject []
 
   -- Products are serialised as { "_0" : a, "_1" : b, ... , "_x" : n } where the key stands for the
   -- index in the product
-  serialiseJSON ts x (TProd ls) tm = let res = serialiseTNaryProd ts x ls tm [] in
-                                         JObject (zip (makeFields (length ls)) res)
+  serialiseJSON x (TProd ls) tm = let res = serialiseTNaryProd x ls tm [] in
+                                      JObject (zip (makeFields (length ls)) res)
   -- Sums are serialized as { "_x" : term } where x is the index in the sum
-  serialiseJSON ts x (TSum xs) tm =
+  serialiseJSON x (TSum xs) tm =
     let (i ** def) = injectionInv xs tm in
-        JObject [("_"++ show (toNat i), assert_total $ serialiseJSON ts x (index i xs) def)]
+        JObject [("_"++ show (toNat i), assert_total $ serialiseJSON x (index i xs) def)]
 
   -- Mu are serialised as { "inn" : rec } where rec is the sum associated with a constructor
-  serialiseJSON ts ws (TMu td) (Inn x) =
+  serialiseJSON {ts} ws (TMu td) (Inn x) =
       JObject [("inn",  assert_total $
-        serialiseJSON ((Mu ts (args td))::ts) ((serialiseJSONMu {td=args td} ts ws)::ws) (args td) x)]
+      serialiseJSON {ts=((Mu ts (args td))::ts)} ((serialiseJSONMu {td=args td} ws)::ws) (args td) x)]
 
   -- TApp applies the tdef to its argument and then serialises the result
-  serialiseJSON ts ws (TApp f ys) tm =
-        assert_total $ serialiseJSON ts ws (ap (def f) ys) (convertTy' tm)
+  serialiseJSON ws (TApp f ys) tm =
+        assert_total $ serialiseJSON ws (ap (def f) ys) (convertTy' tm)
 
   -- References and variables simply defer to the vector of writers
-  serialiseJSON (_::_)    (w::_)    (RRef FZ)          x = w x
-  serialiseJSON (_::_::_) (_::w::_) (RRef (FS FZ))     x = w x
-  serialiseJSON (_::ts)   (_::ws)   (RRef (FS (FS i))) x = serialiseJSON ts ws (RRef (FS i)) x
-  serialiseJSON (_::_)    (w::_)    (TVar FZ)          x = w x
-  serialiseJSON (_::_::_) (_::w::_) (TVar (FS FZ))     x = w x
-  serialiseJSON (_::ts)   (_::ws)   (TVar (FS (FS i))) x = serialiseJSON ts ws (TVar (FS i)) x
+  serialiseJSON (w::_)    (RRef FZ)          x = w x
+  serialiseJSON (_::w::_) (RRef (FS FZ))     x = w x
+  serialiseJSON (_::ws)   (RRef (FS (FS i))) x = serialiseJSON ws (RRef (FS i)) x
+  serialiseJSON (w::_)    (TVar FZ)          x = w x
+  serialiseJSON (_::w::_) (TVar (FS FZ))     x = w x
+  serialiseJSON (_::ws)   (TVar (FS (FS i))) x = serialiseJSON ws (TVar (FS i)) x
+
+public export
+TDefSerialiser JSON where
+  serialise = serialiseJSON

--- a/src/Typedefs/Test/JSONFormatTests.idr
+++ b/src/Typedefs/Test/JSONFormatTests.idr
@@ -16,13 +16,13 @@ import Language.JSON
 %default total
 
 roundtrip1 : (td : TDefR 0) -> Ty [] td -> JSONM (Ty [] td)
-roundtrip1 td x = deserialiseJSON td [] $ serialiseJSON [] [] td x
+roundtrip1 td x = deserialiseJSON td [] $ serialise [] td x
 
 shouldBeRoundtrip1 : (td : TDefR 0) -> (Show (Ty [] td), Eq (Ty [] td)) => Ty [] td -> SpecResult
 shouldBeRoundtrip1 td term = (roundtrip1 td term) `shouldBe` (pure term)
 
 roundtrip2 : (td : TDefR 0) -> JSON -> JSONM JSON
-roundtrip2 td x = serialiseJSON [] [] td <$> deserialiseJSON td [] x
+roundtrip2 td x = serialise [] td <$> deserialiseJSON td [] x
 
 Eq JSON where
   (JNumber a) == (JNumber b) = a == b
@@ -55,23 +55,23 @@ testSuite = spec $ do
   describe "TermWrite" $ do
 
     it "serialise unit" $
-      (serialiseJSON [] [] T1 ()) `shouldBe` junit
+      (serialise [] T1 ()) `shouldBe` junit
 
     it "serialise sum" $
-      (serialiseJSON [] [] (TSum [T1, T1]) (Left ())) `shouldBe` jleft junit
+      (serialise [] (TSum [T1, T1]) (Left ())) `shouldBe` jleft junit
 
     it "serialise prod with var" $
-      (serialiseJSON [Double] [JNumber] (TProd [T1, TVar 0]) ((), 2)) `shouldBe`
+      (serialise [JNumber] (TProd [T1, TVar 0]) ((), 2)) `shouldBe`
         (jpair junit (JNumber 2))
 
     it "serialise mu" $
-      (serialiseJSON [Double] [JNumber] (TMu [("Nil", T1), ("Cons", TProd [TVar 1, TVar 0])])
+      (serialise [JNumber] (TMu [("Nil", T1), ("Cons", TProd [TVar 1, TVar 0])])
         (Inn $ Right (1, Inn $ Right (2, Inn $ Left ()))))
       `shouldBe`
         (jinn $ jright $ jpair (JNumber 1)
                                (jinn $ jright $ jpair (JNumber 2) (jinn $ jleft $ JObject [])))
     it "serialise mu step" $
-      (serialiseJSON [] []
+      (serialise []
           (TMu [("Nil", T1),
                 ("Cons", TProd [(TMu [("Z", T1),
                                       ("S", TVar 0)]), TVar 0])])
@@ -102,21 +102,21 @@ testSuite = spec $ do
     it "deserialise unit" $
       (deserialiseJSON T1 [] (JObject [])) `shouldBe` (pure ())
 
-    it "deserialise sum" $
+    it "deserialiseJSON sum" $
       (deserialiseJSON (TSum [T1, T1]) [] (JObject [("_0", JObject [])])) `shouldBe` (pure $ Left ())
 
-    it "deserialise prod with var" $
+    it "deserialiseJSON prod with var" $
       (deserialiseJSON (TProd [T1, TVar 0]) [MkDPair Int parseInt] (jpair (JObject []) (JNumber 2)))
       `shouldBe` (pure ((), 2))
 
-    it "deserialise mu" $
+    it "deserialiseJSON mu" $
       (deserialiseJSON (TMu [("Nil", T1), ("Cons", TProd [T1, TVar 0])]) []
         (jinn $ jright $ jpair (JObject [])
                                (jinn $ jright $ jpair (JObject [])
                                                       (jinn $ jleft $ JObject []))))
       `shouldBe`
         (pure (Inn (Right ((), Inn (Right ((), Inn (Left ())))))))
-    it "deserialise mu step" $
+    it "deserialiseJSON mu step" $
       (deserialiseJSON
           (TMu [("Nil", T1),
                 ("Cons", TProd [(TMu [("Z", T1),

--- a/src/Typedefs/Test/TermParseWriteTests.idr
+++ b/src/Typedefs/Test/TermParseWriteTests.idr
@@ -13,40 +13,34 @@ import Specdris.Spec
 
 %access public export
 
-roundtrip1 : (td : TDefR 0) -> Ty [] td -> Maybe ((Ty [] td), Bytes)
-roundtrip1 td x = deserialiseBinaryClosed td $ serialise [] td x
-
-roundtrip2 : (td : TDefR 0) -> Bytes -> Maybe Bytes
-roundtrip2 td b = map (serialise [] td . fst) (deserialiseBinaryClosed td b)
-
 testSuite : IO ()
 testSuite = spec $ do
 
   describe "TermWrite" $ do
 
     it "serialise unit" $
-      (serialise [] T1 ()) `shouldBe` "()"
+      (serialise [] [] T1 ()) `shouldBe` "()"
 
     it "serialise sum" $
-      (serialise [] (TSum [T1, T1]) (Left ())) `shouldBe` "(left ())"
+      (serialise [] [] (TSum [T1, T1]) (Left ())) `shouldBe` "(left ())"
 
     it "serialise prod with var" $
-      (serialise [show] (TProd [T1, TVar 0]) ((), 2)) `shouldBe` "(both () 2)"
+      (serialise [] [show] (TProd [T1, TVar 0]) ((), 2)) `shouldBe` "(both () 2)"
 
     it "serialise mu" $
-      (serialise [show] TList (Inn $ Right (1, Inn $ Right (2, Inn $ Left ()))))
+      (serialise [] [show] TList (Inn $ Right (1, Inn $ Right (2, Inn $ Left ()))))
       `shouldBe`
       "(inn (right (both 1 (inn (right (both 2 (inn (left ()))))))))"
 
     it "serialise nested mu" $
-      (serialise [] (TList `ap` [TNat]) (fromList {tdef=TNat} $ map fromNat [3,2,1]))
+      (serialise [] [] (TList `ap` [TNat]) (fromList {tdef=TNat} $ map fromNat [3,2,1]))
         `shouldBe`
       ("(inn (right (both (inn (right (inn (right (inn (right (inn (left ())))))))) " ++
        "(inn (right (both (inn (right (inn (right (inn (left ())))))) " ++
        "(inn (right (both (inn (right (inn (left ())))) (inn (left ())))))))))))")
 
     it "serialise doubly nested mu specified via partial application" $
-      (serialise [] ((TList `ap` [TList]) `ap` [TNat]) (fromList {tdef=TList `ap` [TNat]} (map (fromList {tdef=TNat} . map fromNat) [[1],[2]])))
+      (serialise [] []((TList `ap` [TList]) `ap` [TNat]) (fromList {tdef=TList `ap` [TNat]} (map (fromList {tdef=TNat} . map fromNat) [[1],[2]])))
         `shouldBe`
       ("(inn (right (both (inn (right (both (inn (right (inn (left ())))) (inn (left ()))))) " ++
        "(inn (right (both (inn (right (both (inn (right (inn (right (inn (left ())))))) (inn (left ()))))) (inn (left ()))))))))")

--- a/src/Typedefs/Test/TermParseWriteTests.idr
+++ b/src/Typedefs/Test/TermParseWriteTests.idr
@@ -14,39 +14,39 @@ import Specdris.Spec
 %access public export
 
 roundtrip1 : (td : TDefR 0) -> Ty [] td -> Maybe ((Ty [] td), Bytes)
-roundtrip1 td x = deserialiseBinaryClosed td $ serializeBinaryClosed td x
+roundtrip1 td x = deserialiseBinaryClosed td $ serialise [] td x
 
 roundtrip2 : (td : TDefR 0) -> Bytes -> Maybe Bytes
-roundtrip2 td b = map (serializeBinaryClosed td . fst) (deserialiseBinaryClosed td b)
+roundtrip2 td b = map (serialise [] td . fst) (deserialiseBinaryClosed td b)
 
 testSuite : IO ()
 testSuite = spec $ do
 
   describe "TermWrite" $ do
 
-    it "serialize unit" $
-      (serialize [] [] T1 ()) `shouldBe` "()"
+    it "serialise unit" $
+      (serialise [] T1 ()) `shouldBe` "()"
 
-    it "serialize sum" $
-      (serialize [] [] (TSum [T1, T1]) (Left ())) `shouldBe` "(left ())"
+    it "serialise sum" $
+      (serialise [] (TSum [T1, T1]) (Left ())) `shouldBe` "(left ())"
 
-    it "serialize prod with var" $
-      (serialize [Integer] [show] (TProd [T1, TVar 0]) ((), 2)) `shouldBe` "(both () 2)"
+    it "serialise prod with var" $
+      (serialise [show] (TProd [T1, TVar 0]) ((), 2)) `shouldBe` "(both () 2)"
 
-    it "serialize mu" $
-      (serialize [Integer] [show] TList (Inn $ Right (1, Inn $ Right (2, Inn $ Left ()))))
+    it "serialise mu" $
+      (serialise [show] TList (Inn $ Right (1, Inn $ Right (2, Inn $ Left ()))))
       `shouldBe`
       "(inn (right (both 1 (inn (right (both 2 (inn (left ()))))))))"
 
-    it "serialize nested mu" $
-      (serialize [] [] (TList `ap` [TNat]) (fromList {tdef=TNat} $ map fromNat [3,2,1]))
+    it "serialise nested mu" $
+      (serialise [] (TList `ap` [TNat]) (fromList {tdef=TNat} $ map fromNat [3,2,1]))
         `shouldBe`
       ("(inn (right (both (inn (right (inn (right (inn (right (inn (left ())))))))) " ++
        "(inn (right (both (inn (right (inn (right (inn (left ())))))) " ++
        "(inn (right (both (inn (right (inn (left ())))) (inn (left ())))))))))))")
 
-    it "serialize doubly nested mu specified via partial application" $
-      (serialize [] [] ((TList `ap` [TList]) `ap` [TNat]) (fromList {tdef=TList `ap` [TNat]} (map (fromList {tdef=TNat} . map fromNat) [[1],[2]])))
+    it "serialise doubly nested mu specified via partial application" $
+      (serialise [] ((TList `ap` [TList]) `ap` [TNat]) (fromList {tdef=TList `ap` [TNat]} (map (fromList {tdef=TNat} . map fromNat) [[1],[2]])))
         `shouldBe`
       ("(inn (right (both (inn (right (both (inn (right (inn (left ())))) (inn (left ()))))) " ++
        "(inn (right (both (inn (right (both (inn (right (inn (right (inn (left ())))))) (inn (left ()))))) (inn (left ()))))))))")

--- a/src/Typedefs/TypedefsDecEq.idr
+++ b/src/Typedefs/TypedefsDecEq.idr
@@ -6,25 +6,26 @@ import Typedefs.Typedefs
 
 %default total
 %access public export
-
 -- injectivity proofs
 
-tsumInj : {a : Vect (2+n) (TDef k)} -> {b : Vect (2+m) (TDef k)} -> TSum a = TSum b -> a = b
+tsumInj : {a : Vect (2+n) (TDef' k b)} -> {b : Vect (2+m) (TDef' k b)} -> TSum a = TSum b -> a = b
 tsumInj Refl = Refl
 
-tprodInj : {a : Vect (2+n) (TDef k)} -> {b : Vect (2+m) (TDef k)} -> TProd a = TProd b -> a = b
+tprodInj : {a : Vect (2+n) (TDef' k b)} -> {b : Vect (2+m) (TDef' k b)} -> TProd a = TProd b -> a = b
 tprodInj Refl = Refl
 
 tvarInj : {i, j : Fin (S n)} -> TVar i = TVar j -> i = j
 tvarInj Refl = Refl
 
-tmuInj : {a : Vect k1 (Name, TDef (S n))} -> {b : Vect k2 (Name, TDef (S m))} -> TMu a = TMu b -> a = b
+tmuInj : {a : Vect k1 (Name, TDef' (S n) b)} -> {b : Vect k2 (Name, TDef' (S m) b)} -> TMu a = TMu b -> a = b
 tmuInj Refl = Refl
 
-tappInjNamed : {t : TNamed k} -> {u : TNamed k1} -> {a : Vect k (TDef n)} -> {b : Vect k1 (TDef m)} -> TApp t a = TApp u b -> t = u
+tappInjNamed : {t : TNamed' k b} -> {u : TNamed' k1 b} -> {a : Vect k (TDef' n b)} ->
+               {b : Vect k1 (TDef' m b)} -> TApp t a = TApp u b -> t = u
 tappInjNamed Refl = Refl
 
-tappInjVect : {t : TNamed k} -> {u : TNamed k1} -> {a : Vect k (TDef n)} -> {b : Vect k1 (TDef m)} -> TApp t a = TApp u b -> a = b
+tappInjVect : {t : TNamed' k b} -> {u : TNamed' k1 b} -> {a : Vect k (TDef' n b)} ->
+              {c : Vect k1 (TDef' m b)} -> TApp t a = TApp u c -> a = c
 tappInjVect Refl = Refl
 
 vectInj : {xs : Vect n a} -> {xs' : Vect m a} -> xs = xs' -> n = m
@@ -33,7 +34,7 @@ vectInj Refl = Refl
 tnameInjName : {name, name' : String} -> TName name def = TName name' def' -> name = name'
 tnameInjName Refl = Refl
 
-tnameInjDef : {def, def' : TDef k} -> TName name def = TName name' def' -> def = def'
+tnameInjDef : {def, def' : TDef' k b} -> TName name def = TName name' def' -> def = def'
 tnameInjDef Refl = Refl
 
 frefInj : (FRef r = FRef r') -> r = r'
@@ -149,7 +150,7 @@ tAppNotFRef Refl impossible
 -- decidable equality proofs
 
 mutual
-  DecEq (TDef n) where
+  DecEq (TDef' n v) where
     decEq T0              T0                   = Yes Refl
     decEq T1              T1                   = Yes Refl
     decEq (TSum {k} xs)   (TSum {k=k2} xs')    with (decEq k k2)
@@ -238,7 +239,7 @@ mutual
     decEq (FRef x)      (TApp y xs)            = No $ negEqSym tAppNotFRef
     decEq _ _ = No $ believe_me
 
-  DecEq (TNamed n) where
+  DecEq (TNamed' n b) where
     decEq (TName name def) (TName name' def') with (decEq name name')
       decEq (TName name def) (TName name def')  | Yes Refl with (decEq def def')
         decEq (TName name def) (TName name def)   | Yes Refl | Yes Refl = Yes Refl

--- a/typedefs-core.ipkg
+++ b/typedefs-core.ipkg
@@ -4,6 +4,7 @@ modules = Typedefs.Names
         , Typedefs.Text
         , Typedefs.Parse
         , Typedefs.Idris
+        , Typedefs.DependentLookup
         , Typedefs.Typedefs
         , Typedefs.Library
         , Typedefs.TypedefsDecEq


### PR DESCRIPTION
This PR almost entirely rewrites` TermParse.idr`, the engine responsible to handle Idris backend formats.

Typedefs has multiple backends, the Idris backend is one of them. It generates serialisation functions from Typedefs to a `target` format as an Idris type. Currently our Idris backend supports 3 formats: Binary, String and JSON.

The new `Ty'` function allows to interpret an Idris type and dynamically replace occurrences of specialised types in their target backend, including types with kind `* -> *` like `List`. However, our idris backend could only handle types 

This PR unifies all three backends in a single interface `TDefSerialiser` which expects 4 methods:

- `unilVal`, The unit value in the target backend
- `foldSum`, how to combine a sum in the target backend
- `foldProd`, how to combine a product in the target backend
- `muPrefix`, a simple wrapper function around a mu value

Type application and Mus are handled automatically, including their replacement with specialised types of arbitrary kinds even in nested position. Implementing those methods unlocks the `serialise` methods which serialises any arbitrary `TDef` in the target format. Here is the example directly borrowed from FSM-oracle:

```idris
-- a list of pairs that contains lists of nats, as an idris type this is List (List Nat, List Nat)
listEdges : TDefR 0
listEdges = TApp (TName "" TList)
                 [TProd [TApp (TName "" TList) [TNat] ,
                         TApp (TName "" TList) [TNat]]]

serialise StandardContext [] listEdges
          [([1,2], [0]), ([],[1,2,3])] `shouldBe`
   JArray [ jpair (JArray [JNumber 1, JNumber 2])
                  (JArray [JNumber 0])
         , jpair (JArray [])
                 (JArray [JNumber 1, JNumber 2, JNumber 3])
```

This exact definition is in the JSON format tests in `JSONFormatTests.idr`