### PR TITLE
Implement termWrite with replacement context for type constructors

### DIFF
--- a/src/Typedefs/TermParse.idr
+++ b/src/Typedefs/TermParse.idr
@@ -17,94 +17,45 @@ import Language.JSON
 %default total
 %access public export
 
--- deserialization
+---------------------------------------------------------------------------------------------
+-- Parser & Interfaces                                                                     --
+---------------------------------------------------------------------------------------------
 
-Parser' : Type -> Nat -> Type
-Parser' = Parser TParsecU (sizedtok Char)
+-- A simple Parser, a wrapper for a parsing function `a -> m (b, a)`
+data SParser : (Type -> Type) -> Type -> Type -> Type where
+  MkSParser : Monad m => (source -> m (target, source)) -> SParser m source target
 
-data HasParsers : Vect n Type -> Nat -> Type where
-  Nil : HasParsers Nil m
-  (::) : {xs : Vect n Type} -> Parser' x m -> HasParsers xs m -> HasParsers (x :: xs) m
+-- Special syntax for a parser using monad `m`
+syntax [a] "-[" [m] "]->" [b] = SParser m a b
 
-mutual
-  muParser : {td : TDefR (S n)} -> (ts : Vect n Type) -> All (HasParsers ts :-> Parser' (Mu ts td))
-  muParser {td} ts ps = assert_total $ map (\ty => Inn' {tvars = ts} {m = td} ty) $
-                        parens (rand (string "inn")
-                                     (withSpaces $ chooseParser td ((Mu ts td)::ts) ((muParser ts ps)::ps)))
+run : (src -[m]-> trg) -> src -> m (trg, src)
+run (MkSParser p) = p
 
-  chooseParser : (t : TDefR n) -> (ts : Vect n Type) -> All (HasParsers ts :-> Parser' (Ty ts t))
-  chooseParser T0                    _         _         = fail
-  chooseParser T1                    _         _         = cmap () $ string "()"
-  chooseParser (TSum [x,y])          ts        ps        =
-    parens $ sum (rand (string "left")  (withSpaces $ chooseParser x ts ps))
-                 (rand (string "right") (withSpaces $ chooseParser y ts ps))
-  chooseParser (TSum (x::y::z::zs))  ts        ps        =
-    parens $ sum (rand (string "left")  (withSpaces $ chooseParser x ts ps))
-                 (rand (string "right") (withSpaces $ assert_total $ chooseParser (TSum (y::z::zs)) ts ps))
-  chooseParser (TProd [x,y])         ts        ps        =
-    parens $ rand (string "both") (and (withSpaces $ chooseParser x ts ps)
-                                       (withSpaces $ chooseParser y ts ps))
-  chooseParser (TProd (x::y::z::zs)) ts        ps        =
-    parens $ rand (string "both") (and (withSpaces $ chooseParser x ts ps)
-                                       (withSpaces $ assert_total $ chooseParser (TProd (y::z::zs)) ts ps))
-  chooseParser (TVar FZ)             (_::_)    (p::_)    = p
-  chooseParser (TVar (FS FZ))        (_::_::_) (_::p::_) = p
-  chooseParser (TVar (FS (FS i)))    (_::ts)   (_::ps)   = chooseParser (TVar (FS i)) ts ps
-  chooseParser (TApp (TName n def) xs)           ts        ps        =
-    assert_total $ chooseParser (ap def xs) ts ps
-  chooseParser (RRef FZ)             (_::_)    (p::_)    = p
-  chooseParser (RRef (FS FZ))        (_::_::_) (_::p::_) = p
-  chooseParser (RRef (FS (FS i)))    (_::ts)   (_::ps)   = chooseParser (RRef (FS i)) ts ps
-  chooseParser (TMu td)              ts        ps        =
-     map (\ty => Inn' {tvars = ts} {m = args td} ty) $
-     parens (rand (string "inn")
-                  (withSpaces $ assert_total $ chooseParser (args td) ((Mu ts (args td))::ts)
-                                                                      ((muParser ts ps)::ps)))
+runParser : (Functor m) => (src -[m]-> trg) -> src -> m trg
+runParser (MkSParser p) s = Basics.fst <$> p s
 
-deserialise : (ts : Vect n Type) -> All (HasParsers ts) -> (td : TDefR n) -> String -> Maybe (Ty ts td)
-deserialise ts ps td s  = parseMaybe s (chooseParser td ts ps)
+||| A proof that each type variable has a suitable parser
+data HasParser : (Type -> Type) -> (format : Type) -> Vect n Type -> Type where
+  Nil : HasParser m format []
+  (::) : Monad m => (src -[m]-> trg) -> HasParser m src ts -> HasParser m src (trg :: ts)
 
--- Binary deserialization
+Monad m => Functor (SParser m s) where
+  map f (MkSParser ma) = MkSParser $ \bs => do
+    (a', bs') <- ma bs
+    pure (f a', bs')
 
+Monad m => Applicative (SParser m s) where
+  pure x = MkSParser (pure . MkPair x)
 
-data GenericDeserialiser : Type -> Type -> Type where
-  MkGenericDeserialiser : (b -> Maybe (a, b)) -> GenericDeserialiser b a
+  (<*>) (MkSParser mf) (MkSParser ma) = MkSParser $ \bs => do
+      (f', bs') <- mf bs
+      (a', bs'') <- ma bs'
+      pure (f' a', bs'')
 
-Deserialiser : Type -> Type
-Deserialiser = GenericDeserialiser Bytes
-
-runDeserialiser : GenericDeserialiser b a -> b -> Maybe (a, b)
-runDeserialiser (MkGenericDeserialiser d) = d
-
-Functor (GenericDeserialiser a) where
-  map f ma = MkGenericDeserialiser (\ bs => do
-    (a', bs') <- runDeserialiser ma bs
-    pure (f a', bs'))
-
-Applicative (GenericDeserialiser b) where
-  pure x = MkGenericDeserialiser (pure . MkPair x)
-  mf <*> ma =  MkGenericDeserialiser (\ bs => do
-    (f', bs') <- runDeserialiser mf bs
-    (a', bs'') <- runDeserialiser ma bs'
-    pure (f' a', bs''))
-
-Monad (GenericDeserialiser b) where
-  ma >>= g = MkGenericDeserialiser (\ bs => do
-    (a', bs') <- runDeserialiser ma bs
-    runDeserialiser (g a') bs')
-
-  join ma = MkGenericDeserialiser (\ bs => do
-    (ma', bs') <- runDeserialiser ma bs
-    runDeserialiser ma' bs')
-
-fail : GenericDeserialiser b a
-fail = MkGenericDeserialiser (const Nothing)
-
--- ||| Interprets the first byte as an Int, and returns the rest of the bytestring, if possible
-deserialiseInt : (n : Nat) -> Deserialiser (Fin n)
-deserialiseInt n = MkGenericDeserialiser (\ bs => case (consView bs) of
-    Nil => Nothing
-    Cons b bs' => map (flip MkPair bs') $ integerToFin (prim__zextB8_BigInt b) n)
+Monad m => Monad (SParser m s) where
+  (>>=) (MkSParser ma) g = MkSParser $ \bs => do
+      (a', bs') <- ma bs
+      run (g a') bs'
 
 injection : (i : Fin (2 + k)) -> (ts : Vect (2 + k) (TDefR n)) -> Ty tvars (index i ts) -> Tnary tvars ts Either
 injection FZ      [a, b]             x = Left x
@@ -112,128 +63,247 @@ injection (FS FZ) [a, b]             x = Right x
 injection FZ     (a :: b :: c :: ts) x = Left x
 injection (FS i) (a :: b :: c :: ts) x = Right (injection i (b :: c :: ts) x)
 
-deserialiseBinary : (t : TDefR n) -> (ts : Vect n (a ** Deserialiser a)) -> Deserialiser (Ty (map DPair.fst ts) t)
-deserialiseBinary T0 ts = fail -- will never happen!
-deserialiseBinary T1 ts = pure ()
-deserialiseBinary td@(TSum {k = k} tds) ts = do
-  i <- deserialiseInt (2 + k)
-  t' <- deserialiseBinary (assert_smaller td (index i tds)) ts
-  pure (injection i tds t')
-deserialiseBinary (TProd [a, b]) ts = do
-  ta <- deserialiseBinary a ts
-  tb <- deserialiseBinary b ts
-  pure (ta, tb)
-deserialiseBinary td@(TProd (a ::  b :: c :: tds)) ts = do
-  ta <- deserialiseBinary a ts
-  t' <- deserialiseBinary (assert_smaller td (TProd (b :: c :: tds))) ts
-  pure (ta, t')
-deserialiseBinary (TMu tds) ts = do
-  t <- assert_total $ deserialiseBinary (args tds) ((Mu (map DPair.fst ts) (args tds) ** assert_total $ deserialiseBinary (TMu tds) ts)::ts)
-  pure (Inn t)
-deserialiseBinary (TVar FZ) (t::ts) = snd t
-deserialiseBinary {n = S (S n')} (TVar (FS i)) (t::ts) = deserialiseBinary {n = S n'} (TVar i) ts
-deserialiseBinary (TApp (TName name def) xs) ts = assert_total $ deserialiseBinary (ap def xs) (ts)
-deserialiseBinary (RRef n) ts = fail -- we dont' support reference types
+failParser : Monad m => (error : m Void) -> s -[m]-> Void
+failParser error = MkSParser $ \arg => void <$> error
 
-deserialiseBinaryClosed : (t : TDefR 0) -> Bytes-> Maybe ((Ty [] t), Bytes)
-deserialiseBinaryClosed t = runDeserialiser (deserialiseBinary t [])
+getVar : {vs : Vect n Type} -> (i : Fin n) ->  HasParser m format vs -> (format -[m]-> index i vs)
+getVar FZ (p::ps) = p
+getVar {n = S (S n')} (FS i) (p::ps) =
+  getVar {n = S n'} i ps
 
 
+public export
+interface (Monad m) => TDefDeserialiser (m : Type -> Type) format where
+
+  voidError : m Void
+
+  parseProd : {ts : Vect n Type} -> HasParser m format ts -> (args : Vect (2 + k) (TDefR n)) ->
+             (format -[m]-> (Ty ts (TProd args)))
+
+  parseSum : {ts : Vect n Type} -> HasParser m format ts -> (args : Vect (2 + k) (TDefR n)) ->
+             (format -[m]-> (Ty ts (TSum args)))
+
+  parseMu : format -[m]-> ()
+  parseMu = MkSParser $ pure . MkPair ()
+
+deserialiser : {m : Type -> Type} -> {format : Type} -> (TDefDeserialiser m format) =>
+               {ts : Vect n Type} -> HasParser m format ts ->
+               (td : TDefR n) -> (format -[m]-> (Ty ts td))
+deserialiser ps T0 = failParser (voidError {m} {format})
+deserialiser ps T1 = pure ()
+deserialiser ps (TSum {k = k} tds) = parseSum ps tds
+deserialiser ps (TProd products {k}) = parseProd ps products
+deserialiser ps (TMu tds) {ts} = do
+  () <- parseMu
+  let muParser = assert_total $ deserialiser ps (TMu tds)
+  parsed <- assert_total $ deserialiser (muParser :: ps) (args tds)
+  pure (Inn parsed)
+deserialiser p (TVar i) = getVar i p
+deserialiser p (RRef i) = getVar i p
+deserialiser ps (TApp (TName name def) xs) = assert_total $ deserialiser ps (ap def xs)
+
+
+export
+deserialise : (Monad m, TDefDeserialiser m format) =>  {ts : Vect n Type} ->
+              HasParser m format ts -> (td : TDefR n) ->
+              format -> m (Ty ts td)
+deserialise ps td = TermParse.runParser $ deserialiser ps td
+
+---------------------------------------------------------------------------------------------
+-- Strings                                                                                 --
+----                                                                                       --
+-- The string parser is different so we leave it in its own namespace without implementing --
+-- the common TDefDeserialiser interface.                                                  --
+---------------------------------------------------------------------------------------------
+
+namespace StringParser
+  Parser' : Type -> Nat -> Type
+  Parser' = Parser TParsecU (sizedtok Char)
+
+  data StringParsers : Vect n Type -> Nat -> Type where
+    Nil : StringParsers Nil m
+    (::) : {xs : Vect n Type} -> Parser' x m -> StringParsers xs m -> StringParsers (x :: xs) m
+
+  mutual
+    muParser : {td : TDefR (S n)} -> (ts : Vect n Type) -> All (StringParsers ts :-> Parser' (Mu ts td))
+    muParser {td} ts ps = assert_total $ map (\ty => Inn' {tvars = ts} {m = td} ty) $
+                          parens (rand (string "inn")
+                                       (withSpaces $ chooseParser td ((Mu ts td)::ts) ((muParser ts ps)::ps)))
+
+    chooseParser : (t : TDefR n) -> (ts : Vect n Type) -> All (StringParsers ts :-> Parser' (Ty ts t))
+    chooseParser T0                    _         _         = fail
+    chooseParser T1                    _         _         = cmap () $ string "()"
+    chooseParser (TSum [x,y])          ts        ps        =
+      parens $ sum (rand (string "left")  (withSpaces $ chooseParser x ts ps))
+                   (rand (string "right") (withSpaces $ chooseParser y ts ps))
+    chooseParser (TSum (x::y::z::zs))  ts        ps        =
+      parens $ sum (rand (string "left")  (withSpaces $ chooseParser x ts ps))
+                   (rand (string "right") (withSpaces $ assert_total $ chooseParser (TSum (y::z::zs)) ts ps))
+    chooseParser (TProd [x,y])         ts        ps        =
+      parens $ rand (string "both") (and (withSpaces $ chooseParser x ts ps)
+                                         (withSpaces $ chooseParser y ts ps))
+    chooseParser (TProd (x::y::z::zs)) ts        ps        =
+      parens $ rand (string "both") (and (withSpaces $ chooseParser x ts ps)
+                                         (withSpaces $ assert_total $ chooseParser (TProd (y::z::zs)) ts ps))
+    chooseParser (TVar FZ)             (_::_)    (p::_)    = p
+    chooseParser (TVar (FS FZ))        (_::_::_) (_::p::_) = p
+    chooseParser (TVar (FS (FS i)))    (_::ts)   (_::ps)   = chooseParser (TVar (FS i)) ts ps
+    chooseParser (TApp (TName n def) xs)           ts        ps        =
+      assert_total $ chooseParser (ap def xs) ts ps
+    chooseParser (RRef FZ)             (_::_)    (p::_)    = p
+    chooseParser (RRef (FS FZ))        (_::_::_) (_::p::_) = p
+    chooseParser (RRef (FS (FS i)))    (_::ts)   (_::ps)   = chooseParser (RRef (FS i)) ts ps
+    chooseParser (TMu td)              ts        ps        =
+       map (\ty => Inn' {tvars = ts} {m = args td} ty) $
+       parens (rand (string "inn")
+                    (withSpaces $ assert_total $ chooseParser (args td) ((Mu ts (args td))::ts)
+                                                                        ((muParser ts ps)::ps)))
+
+  deserialiseStr : {ts : Vect n Type} -> All (StringParsers ts) -> (td : TDefR n) -> String -> Maybe (Ty ts td)
+  deserialiseStr {ts} ps td s  = parseMaybe s (chooseParser td ts ps)
+
+---------------------------------------------------------------------------------------------
+-- Binary                                                                                  --
+---------------------------------------------------------------------------------------------
+
+fail : s -[Maybe]-> a
+fail = MkSParser $ const Nothing
+
+||| Interprets the first byte as an Int, and returns the rest of the bytestring, if possible
+deserialiseInt : (n : Nat) -> (Bytes -[Maybe]-> (Fin n))
+deserialiseInt n = MkSParser $ \bs => case (consView bs) of
+    Nil => Nothing
+    Cons b bs' => flip MkPair bs' <$> integerToFin (prim__zextB8_BigInt b) n
+
+export
+TDefDeserialiser Maybe Bytes where
+
+  voidError = Nothing
+
+  parseSum ps tds {k} = do
+    i <- deserialiseInt (2 + k)
+    t' <- assert_total $ deserialiser ps (index i tds)
+    pure (injection i tds t')
+
+  parseProd ps [a,b] = do
+    ta <- assert_total $ deserialiser ps a
+    tb <- assert_total $ deserialiser ps b
+    pure (ta, tb)
+
+  parseProd ps (a :: b :: c :: tds) = do
+    ta <- assert_total $ deserialiser ps a
+    t' <- assert_total $ deserialiser ps (TProd (b :: c :: tds))
+    pure (ta, t')
+
+---------------------------------------------------------------------------------------------
+-- JSON                                                                                    --
+---------------------------------------------------------------------------------------------
+
+||| Errors when parsing JSON
 JSONM : Type -> Type
 JSONM = Either String
 
-parseObject : JSON -> JSONM (List (String, JSON))
-parseObject (JObject ls) = pure ls
-parseObject _ = Left "expected Object"
+||| Type of parsers that consume JSON
+JParser : Type -> Type
+JParser = SParser (Either String) JSON
 
-parseInt : JSON -> JSONM Int
-parseInt (JNumber n) = pure (cast n)
-parseInt _ = Left "expected Int"
+||| Expect JSON is an object and return its fields
+parseObject : JParser (List (String, JSON))
+parseObject = MkSParser parse
+  where
+    parse : JSON -> JSONM ((List (String, JSON)), JSON)
+    parse (JObject ls) = Right (ls, JNull)
+    parse _ = Left "expected Object"
 
--- check if the key starts with an underscore and if its smaller than 2 + k
-parseKey : String -> JSONM (Fin (2 + k))
-parseKey "" = Left "Invalid key: empty"
-parseKey str {k} = do '_' <- safeHead str | Left ("Invalid key: '" ++ str ++ "'")
-                      rest <- safeTail str
-                      let i = parsePositive rest
-                      index <- (maybeToEither "Invalid key" i)
-                      maybeToEither "Invalid Key" $ natToFin index (2 + k)
+||| Expects JSON is an integer value
+parseInt : JParser Int
+parseInt = MkSParser parse
+  where
+    parse : JSON -> JSONM (Int, JSON)
+    parse (JNumber n) = pure ((cast n), JNull)
+    parse _ = Left "expected Int"
+
+||| check if the key starts with an underscore and if its smaller than 2 + k
+parseKey : (k : Nat) -> String -> JSONM (Fin (2 + k))
+parseKey k "" = Left "Invalid key: empty"
+parseKey k str = do '_' <- safeHead str | Left ("Invalid key: '" ++ str ++ "'")
+                    rest <- safeTail str
+                    let i = parsePositive rest
+                    index <- maybeToEither "Invalid key" i
+                    maybeToEither "Invalid Key" $ natToFin index (2 + k)
     where
       safeStrOp : (String -> a) -> String -> JSONM a
-      safeStrOp op str = if length str > 0 then pure (op str)
+      safeStrOp op str = if length str > 0 then Right (op str)
                                            else Left "expected index"
       safeHead : String -> JSONM Char
       safeHead = assert_total $ safeStrOp strHead
       safeTail : String -> JSONM String
       safeTail = assert_total $ safeStrOp strTail
 
+namespace ParseProduct
+  ||| A proof that each element of a product has been successfully parsed
+  data ParseProd : Vect n Type -> Vect l (TDefR n) -> Type where
+    Nil : ParseProd vs []
+    (::) : {td : TDefR n} -> (parsed : Ty vs td) -> ParseProd vs ts -> ParseProd vs (td::ts)
 
+injProd : {vs : Vect n Type} -> {vec : Vect (2 + k) (TDefR n)} -> ParseProd vs vec
+       -> Tnary vs vec Pair
+injProd [a, b] = (a, b)
+injProd (a :: b :: x :: xs) = (a , injProd (b :: x :: xs))
 
-injProd : (vec : Vect (2 + k) (ts : TDefR n ** Ty tds ts))
-       -> Tnary tds (map DPair.fst vec) Pair
-injProd [(_ ** x), (_ ** y)] = (x, y)
-injProd ((_ ** x) :: y :: z :: zs) = (x, assert_total $ injProd (y :: z :: zs))
+jsonFail : String -> SParser JSONM a b
+jsonFail str = MkSParser (const $ Left str)
 
 -- we need to check all keys are in increasing order and of the format _X from 0 to l
 parseVect : List (String, JSON) -> (l : Nat) -> JSONM (Vect l JSON)
 parseVect ls n = case decEq (length ls) n of
-                      Yes prf => rewrite sym prf in pure $ map snd (fromList ls)
+                      Yes prf => rewrite sym prf in Applicative.pure $ Functor.map snd (fromList ls)
                       No _ => Left ("incompatible lengths: " ++ show (length ls)
                                     ++ " and " ++ show n)
 
-deserialiseJSON : (t : TDefR n) -> (ts : Vect n (a ** (JSON -> JSONM a)))
-               -> JSON -> Either String (Ty (map DPair.fst ts) t)
-deserialiseJSON T0 ts json = Left "parsing 0"
-deserialiseJSON T1 ts json = pure ()
-deserialiseJSON td@(TSum {k = k} tds) ts json =  do
-  [(key, obj)] <- parseObject json
-    | _ => Left "Object doens't contain exactly 1 element"
-  key' <- parseKey key
-  t' <- deserialiseJSON (assert_smaller td (index key' tds)) ts obj
-  pure $ injection key' tds t'
-deserialiseJSON (TProd products {k}) ts json {n} = do
-  keyValues <- parseObject json
-  vec <- parseVect keyValues (2 + k)
-  res <- the (JSONM $ Vect (2 + k) (td : TDefR n ** Ty (map DPair.fst ts) td))
-             (traverse (\(def, j) => MkDPair def <$> (assert_total $ deserialiseJSON def ts j))
-                       (zip products vec))
-  -- Alright explaination time:
-  --
-  -- In the previous line we compute a vector of parsed JSON along with the TDef they are supposed
-  -- to be a member of. This dependent pair comes from zipping `products` and the vector of JSONs
-  -- and then traversing it while parsing the jsons using the TDefs as a schema to say "here is
-  -- the expected type this value shoud parse as".
-  -- However in order to return the Idris type associated with this product type we need a proof
-  -- that the values we parsed (and their type) correspond to the types we expect from `products`
-  -- (which itself is the vector of TDefs that  defines which types we expect in which order).
-  --
-  -- But now we're stuck because we have a vector of (def : TDefR n ** f def) where the first
-  -- projection _is_ the TDef from `products` (because we zipped them and took the first element to
-  -- make the returning DPair), but we don't have a proof of it.
-  --
-  -- I tried using `let prf = the (map fst res = products) (believe_me Refl)` and rewriting but
-  -- it just wouldn't work. In the end, since as a programmer I _know_ this is true because of the
-  -- implementation, I decided to force the hand of the compiler and use `belive_me` at the call
-  -- site of `injprod` (which builds the Idris value from the given product) rather than in a
-  -- rewrite. This is safe but dangerous if we ever change the line right above this scary comment.
-  --
-  -- Please don't ignore this comment when you change the code around those two lines.
-  pure $ believe_me $ injProd res
-deserialiseJSON (TMu tds) ts json = do
-  [("inn", val)] <- parseObject json
-    | [] => Left "Expected inner mu but object was empty"
-    | ls => Left ("Expected exactly one inner mu value, got " ++ (show $ ls))
+||| Lift a function into a parser that operates on the value but does not consume it
+liftParse : Monad m => {a : Type} -> (a -> m b) -> (a -[m]-> b)
+liftParse f = MkSParser (\v => flip MkPair v <$> f v)
 
-  parsed <- assert_total (deserialiseJSON
-              (args tds)
-              ((Mu (map DPair.fst ts) (args tds) ** assert_total $ deserialiseJSON (TMu tds) ts)::ts)
-              val)
-  pure (Inn parsed)
-deserialiseJSON (TVar FZ) ((_ ** t)::ts) json = t json
-deserialiseJSON {n = S (S n')} (TVar (FS i)) ((_ ** t)::ts) json =
-  deserialiseJSON {n = S n'} (TVar i) ts json
-deserialiseJSON (TApp (TName name def) xs) ts json = assert_total $ deserialiseJSON (ap def xs) (ts) json
-deserialiseJSON (RRef FZ) ((_ ** t)::ts) json = t json
-deserialiseJSON {n = S (S n')} (RRef (FS i)) ((_ ** t)::ts) json =
-  deserialiseJSON {n = S n'} (RRef i) ts json
+liftVal : Monad m => m b -> (a -[m]-> b)
+liftVal v = liftParse (const v)
+
+||| Parses an object with a single field. Returns the parsed key and the json as leftover
+parseSingleObject : JParser String
+parseSingleObject = do
+    [v] <- parseObject
+        | jsonFail "Object doens't contain exactly 1 element"
+    MkSParser (const $ pure v)
+
+export
+TDefDeserialiser (Either String) JSON where
+
+  voidError = Left "parsing Void"
+
+  -- mu is an object with a single field called "inn"
+  parseMu = do
+    "inn" <- parseSingleObject
+      | jsonFail "Expected exactly one inner mu value"
+    pure ()
+
+  parseSum ps tds {k} = do
+    key <- parseSingleObject
+    let (Right key') = parseKey k key
+      | Left err => jsonFail err
+    t' <- assert_total $ deserialiser ps (index key' tds)
+    pure (injection key' tds t')
+
+  parseProd ps tds {n} {k} {ts} = do
+      keyValues <- parseObject
+      vec <- liftVal $ parseVect keyValues (2 + k)
+      res <- liftVal $ toParsedProd tds vec
+      pure $ injProd res
+    where
+      toParsedProd : (tds : Vect l (TDefR n)) -> Vect l JSON -> JSONM (ParseProd ts tds)
+      toParsedProd [] [] {l = Z} = pure []
+      toParsedProd (t::tds) (j::js) {l = (S k)} = do
+        r <- runParser (assert_total $ deserialiser ps t) j
+        rs <- toParsedProd tds js
+        pure $ r :: rs
+
 

--- a/src/Typedefs/TermParse.idr
+++ b/src/Typedefs/TermParse.idr
@@ -34,11 +34,6 @@ run (MkSParser p) = p
 runParser : (Functor m) => (src -[m]-> trg) -> src -> m trg
 runParser (MkSParser p) s = Basics.fst <$> p s
 
-||| A proof that each type variable has a suitable parser
-data HasParser : (Type -> Type) -> (format : Type) -> Vect n Type -> Type where
-  Nil : HasParser m format []
-  (::) : Monad m => (src -[m]-> trg) -> HasParser m src ts -> HasParser m src (trg :: ts)
-
 Monad m => Functor (SParser m s) where
   map f (MkSParser ma) = MkSParser $ \bs => do
     (a', bs') <- ma bs
@@ -57,11 +52,52 @@ Monad m => Monad (SParser m s) where
       (a', bs') <- ma bs
       run (g a') bs'
 
-injection : (i : Fin (2 + k)) -> (ts : Vect (2 + k) (TDefR n)) -> Ty tvars (index i ts) -> Tnary tvars ts Either
-injection FZ      [a, b]             x = Left x
-injection (FS FZ) [a, b]             x = Right x
-injection FZ     (a :: b :: c :: ts) x = Left x
-injection (FS i) (a :: b :: c :: ts) x = Right (injection i (b :: c :: ts) x)
+alt : Alternative m => SParser m f a -> SParser m f b -> SParser m f (Either a b)
+alt (MkSParser f) (MkSParser g) =
+  MkSParser $ \arg => map (\(a,r) => (Left a, r)) (f arg)
+                  <|> map (\(b,r) => (Right b, r)) (g arg)
+
+||| A proof that each type variable has a suitable parser
+data HasParser : (Type -> Type) -> (format : Type) -> Vect n Type -> Type where
+  Nil : HasParser m format []
+  (::) : Monad m => (src -[m]-> trg) -> HasParser m src ts -> HasParser m src (trg :: ts)
+
+namespace SpecialisedParser
+  ||| Prove that there is a parser function for every type in the specialisation list
+  data HasSpecialisedParser : (m : Type -> Type) -> (format : Type) -> (sp : SpecialList l) -> Type where
+    Nil : HasSpecialisedParser m format []
+    (::) : {n : Nat} -> {def : TDefR n} -> {constr : TypeConstructor n} ->
+           ({args : Vect n Type} -> HasParser m fmt args -> (fmt -[m]-> ApplyVect constr args)) ->
+           HasSpecialisedParser m fmt sps ->
+           HasSpecialisedParser m fmt ((n ** (def, constr)) :: sps)
+
+lookupParser : Monad m => {sp : SpecialList l } -> {format : Type} ->
+               (e : Elem (n ** (td, constr)) sp) ->
+               (spp : HasSpecialisedParser m format sp) ->
+               {args : Vect n Type} -> HasParser m format args ->
+               (format -[m]-> ApplyVect constr args)
+lookupParser Here (p :: sps) = p
+lookupParser (There e) (p :: sps) = lookupParser e sps
+
+FromTDefToTy : {n : Nat} -> SpecialList l -> Vect n Type -> Vect k (TDefR n) -> Vect k Type
+FromTDefToTy sp types vs = map (Ty' sp types) vs
+
+makeParsers : Monad m => {format : Type} -> {sp : SpecialList l} ->
+              (tys : Vect n Type) ->
+              (spp : HasSpecialisedParser m format sp) ->
+              (gen : HasParser m format tys) ->
+              ((tdef : TDefR n) -> (format -[m]-> (Ty' sp tys tdef))) ->
+              (vs : Vect k (TDefR n)) ->
+              HasParser m format (FromTDefToTy sp tys vs)
+makeParsers tys spp gen fn [] = []
+makeParsers tys spp gen fn (td :: tds) = (fn td) :: (makeParsers tys spp gen fn tds)
+
+injection : (sp : SpecialList l) -> (i : Fin (2 + k)) -> (ts : Vect (2 + k) (TDefR n)) ->
+            Ty' sp tvars (index i ts) -> Tnary' sp tvars ts Either
+injection sp FZ      [a, b]             x = Left x
+injection sp (FS FZ) [a, b]             x = Right x
+injection sp FZ     (a :: b :: c :: ts) x = Left x
+injection sp (FS i) (a :: b :: c :: ts) x = Right (injection sp i (b :: c :: ts) x)
 
 failParser : Monad m => (error : m Void) -> s -[m]-> Void
 failParser error = MkSParser $ \arg => void <$> error
@@ -77,37 +113,51 @@ interface (Monad m) => TDefDeserialiser (m : Type -> Type) format where
 
   voidError : m Void
 
-  parseProd : {ts : Vect n Type} -> HasParser m format ts -> (args : Vect (2 + k) (TDefR n)) ->
-             (format -[m]-> (Ty ts (TProd args)))
+  parseProd : {ts : Vect n Type} -> {sp : SpecialList l} -> HasSpecialisedParser m format sp ->
+              HasParser m format ts -> (args : Vect (2 + k) (TDefR n)) ->
+              (format -[m]-> (Ty' sp ts (TProd args)))
 
-  parseSum : {ts : Vect n Type} -> HasParser m format ts -> (args : Vect (2 + k) (TDefR n)) ->
-             (format -[m]-> (Ty ts (TSum args)))
+  parseSum : {ts : Vect n Type} -> {sp : SpecialList l} -> HasSpecialisedParser m format sp ->
+             HasParser m format ts -> (args : Vect (2 + k) (TDefR n)) ->
+             (format -[m]-> (Ty' sp ts (TSum args)))
 
   parseMu : format -[m]-> ()
   parseMu = MkSParser $ pure . MkPair ()
 
-deserialiser : {m : Type -> Type} -> {format : Type} -> (TDefDeserialiser m format) =>
-               {ts : Vect n Type} -> HasParser m format ts ->
-               (td : TDefR n) -> (format -[m]-> (Ty ts td))
-deserialiser ps T0 = failParser (voidError {m} {format})
-deserialiser ps T1 = pure ()
-deserialiser ps (TSum {k = k} tds) = parseSum ps tds
-deserialiser ps (TProd products {k}) = parseProd ps products
-deserialiser ps (TMu tds) {ts} = do
-  () <- parseMu
-  let muParser = assert_total $ deserialiser ps (TMu tds)
-  parsed <- assert_total $ deserialiser (muParser :: ps) (args tds)
-  pure (Inn parsed)
-deserialiser p (TVar i) = getVar i p
-deserialiser p (RRef i) = getVar i p
-deserialiser ps (TApp (TName name def) xs) = assert_total $ deserialiser ps (ap def xs)
 
+deserialiser : {m : Type -> Type} -> {format : Type} -> (TDefDeserialiser m format) =>
+               {sp : SpecialList l} ->
+               {ts : Vect n Type} ->
+               (spp : HasSpecialisedParser m format sp) ->
+               HasParser m format ts -> (td : TDefR n) ->
+               (format -[m]-> (Ty' sp ts td))
+deserialiser spp ps T0 = failParser (voidError {m} {format})
+deserialiser spp ps T1 = pure ()
+deserialiser spp ps (TSum {k = k} tds) = parseSum spp ps tds
+deserialiser spp ps (TProd products {k}) = parseProd spp ps products
+deserialiser spp {sp} ps (TMu tds) {ts} with (depLookup sp (TMu tds))
+  deserialiser spp ps (TMu tds) {ts} | Nothing = do
+    () <- parseMu
+    let muParser = assert_total $ deserialiser spp ps (TMu tds)
+    parsed <- assert_total $ deserialiser spp (muParser :: ps) (args tds)
+    pure (Inn (believe_me parsed))
+  deserialiser spp ps  (TMu tds) {ts} | Just (def ** constr ** el) = do
+    lookupParser el spp ps
+deserialiser spp p (TVar i) = getVar i p
+deserialiser spp p (RRef i) = getVar i p
+deserialiser spp ps {sp} {ts} (TApp (TName name def) xs) with (depLookup sp def)
+  deserialiser spp ps {sp} {ts} (TApp (TName name def) xs) | Nothing =
+    assert_total $ deserialiser spp ps (ap def xs)
+  deserialiser spp ps {sp} {ts} (TApp (TName name def) xs) | Just (_ ** constr ** el) =
+    lookupParser el spp (makeParsers ts spp ps (assert_total $ deserialiser spp ps) xs)
 
 export
-deserialise : (Monad m, TDefDeserialiser m format) =>  {ts : Vect n Type} ->
-              HasParser m format ts -> (td : TDefR n) ->
-              format -> m (Ty ts td)
-deserialise ps td = TermParse.runParser $ deserialiser ps td
+deserialise : (Monad m, TDefDeserialiser m format) =>
+              {sp : SpecialList l} ->
+              {ts : Vect n Type} ->
+              HasSpecialisedParser m format sp -> HasParser m format ts -> (td : TDefR n) ->
+              format -> m (Ty' sp ts td)
+deserialise spp ps td = TermParse.runParser $ deserialiser spp ps td
 
 ---------------------------------------------------------------------------------------------
 -- Strings                                                                                 --
@@ -180,19 +230,19 @@ TDefDeserialiser Maybe Bytes where
 
   voidError = Nothing
 
-  parseSum ps tds {k} = do
+  parseSum spp ps tds {sp} {k} = do
     i <- deserialiseInt (2 + k)
-    t' <- assert_total $ deserialiser ps (index i tds)
-    pure (injection i tds t')
+    t' <- assert_total $ deserialiser spp ps (index i tds)
+    pure (injection sp i tds t')
 
-  parseProd ps [a,b] = do
-    ta <- assert_total $ deserialiser ps a
-    tb <- assert_total $ deserialiser ps b
+  parseProd spp ps [a,b] = do
+    ta <- assert_total $ deserialiser spp ps a
+    tb <- assert_total $ deserialiser spp ps b
     pure (ta, tb)
 
-  parseProd ps (a :: b :: c :: tds) = do
-    ta <- assert_total $ deserialiser ps a
-    t' <- assert_total $ deserialiser ps (TProd (b :: c :: tds))
+  parseProd spp ps (a :: b :: c :: tds) = do
+    ta <- assert_total $ deserialiser spp ps a
+    t' <- assert_total $ deserialiser spp ps (TProd (b :: c :: tds))
     pure (ta, t')
 
 ---------------------------------------------------------------------------------------------
@@ -202,6 +252,11 @@ TDefDeserialiser Maybe Bytes where
 ||| Errors when parsing JSON
 JSONM : Type -> Type
 JSONM = Either String
+
+Alternative (Either String) where
+  empty = Left "JSON Error"
+  (<|>) (Right v) _ = Right v
+  (<|>) _ v = v
 
 ||| Type of parsers that consume JSON
 JParser : Type -> Type
@@ -242,14 +297,15 @@ parseKey k str = do '_' <- safeHead str | Left ("Invalid key: '" ++ str ++ "'")
 
 namespace ParseProduct
   ||| A proof that each element of a product has been successfully parsed
-  data ParseProd : Vect n Type -> Vect l (TDefR n) -> Type where
-    Nil : ParseProd vs []
-    (::) : {td : TDefR n} -> (parsed : Ty vs td) -> ParseProd vs ts -> ParseProd vs (td::ts)
+  data ParseProd : (sp : SpecialList l) -> Vect n Type -> Vect k (TDefR n) -> Type where
+    Nil : ParseProd sp vs []
+    (::) : {td : TDefR n} -> {sp : SpecialList l} -> (parsed : Ty' sp vs td) ->
+           ParseProd sp vs ts -> ParseProd sp vs (td::ts)
 
-injProd : {vs : Vect n Type} -> {vec : Vect (2 + k) (TDefR n)} -> ParseProd vs vec
-       -> Tnary vs vec Pair
-injProd [a, b] = (a, b)
-injProd (a :: b :: x :: xs) = (a , injProd (b :: x :: xs))
+injProd : {vs : Vect n Type} -> {vec : Vect (2 + k) (TDefR n)} -> (sp : SpecialList l) ->
+          ParseProd sp vs vec -> Tnary' sp vs vec Pair
+injProd sp [a, b] = (a, b)
+injProd sp (a :: b :: x :: xs) = (a , injProd sp (b :: x :: xs))
 
 jsonFail : String -> SParser JSONM a b
 jsonFail str = MkSParser (const $ Left str)
@@ -275,35 +331,43 @@ parseSingleObject = do
         | jsonFail "Object doens't contain exactly 1 element"
     MkSParser (const $ pure v)
 
+expectSingleField : String -> JParser ()
+expectSingleField str = do
+  parsed <- parseSingleObject
+  if parsed == str then pure ()
+                   else jsonFail $ "expected with single field " ++ str ++ " got " ++ parsed ++ " instead"
+
+toParsedProd : (sp : SpecialList l) ->
+               (ts : Vect n Type) ->
+               ((td : TDefR n) -> JSON -> JSONM (Ty' sp ts td)) ->
+               (tds : Vect k (TDefR n)) ->
+               (Vect k JSON) -> JSONM (ParseProd sp ts tds)
+toParsedProd sp ts rec [] [] {k = Z} = pure []
+toParsedProd sp ts rec (t::tds) (j::js) {k = (S k)} = do
+  r <- rec t j
+  rs <- toParsedProd sp ts rec tds js
+  pure $ r :: rs
+
 export
 TDefDeserialiser (Either String) JSON where
 
   voidError = Left "parsing Void"
 
   -- mu is an object with a single field called "inn"
-  parseMu = do
-    "inn" <- parseSingleObject
-      | jsonFail "Expected exactly one inner mu value"
-    pure ()
+  parseMu = expectSingleField "inn"
 
-  parseSum ps tds {k} = do
+  parseSum spp ps tds {k} {sp} = do
     key <- parseSingleObject
     let (Right key') = parseKey k key
       | Left err => jsonFail err
-    t' <- assert_total $ deserialiser ps (index key' tds)
-    pure (injection key' tds t')
+    t' <- assert_total $ deserialiser spp ps (index key' tds)
+    pure (injection sp key' tds t')
 
-  parseProd ps tds {n} {k} {ts} = do
+  parseProd spp ps tds {n} {k} {ts} {sp} = do
       keyValues <- parseObject
       vec <- liftVal $ parseVect keyValues (2 + k)
-      res <- liftVal $ toParsedProd tds vec
-      pure $ injProd res
-    where
-      toParsedProd : (tds : Vect l (TDefR n)) -> Vect l JSON -> JSONM (ParseProd ts tds)
-      toParsedProd [] [] {l = Z} = pure []
-      toParsedProd (t::tds) (j::js) {l = (S k)} = do
-        r <- runParser (assert_total $ deserialiser ps t) j
-        rs <- toParsedProd tds js
-        pure $ r :: rs
+      res <- liftVal $ toParsedProd sp ts
+               (\tdef => TermParse.runParser $ assert_total $ deserialiser spp ps tdef) tds vec
+      pure $ injProd sp res
 
 

--- a/src/Typedefs/TermWrite.idr
+++ b/src/Typedefs/TermWrite.idr
@@ -35,9 +35,10 @@ namespace SpecialisedWriters
 
 ||| Lookup in the specialised context for the function that converts a special type to its target representation
 lookupTypeReplacement : {sp : SpecialList l} -> (e : Elem (n ** (td, constr)) sp) ->
-              {target : Type} ->
-              (sw : HasSpecialisedWriter target sp) ->
-              {args : Vect n Type} -> HasGenericWriters target args -> ApplyVect constr args -> target
+                        {target : Type} ->
+                        (sw : HasSpecialisedWriter target sp) ->
+                        {args : Vect n Type} -> HasGenericWriters target args ->
+                        ApplyVect constr args -> target
 lookupTypeReplacement Here (s :: sp) = s
 lookupTypeReplacement (There e) (s :: sp) = lookupTypeReplacement e sp
 

--- a/src/Typedefs/Test/TermParseWriteTests.idr
+++ b/src/Typedefs/Test/TermParseWriteTests.idr
@@ -48,13 +48,13 @@ testSuite = spec $ do
   describe "TermParse" $ do
 
     it "deserialise unit" $
-      (deserialise [] [] T1 "()") `shouldBe` (Just ())
+      (deserialiseStr [] T1 "()") `shouldBe` (Just ())
 
     it "deserialise sum" $
-      (deserialise [] [] (TSum [T1, T1]) "(left ())") `shouldBe` (Just (Left ()))
+      (deserialiseStr [] (TSum [T1, T1]) "(left ())") `shouldBe` (Just (Left ()))
 
     it "deserialise prod with var" $
-      (deserialise [Integer] [decimalInteger] (TProd [T1, TVar 0]) "(both () 2)") `shouldBe` (Just ((), 2))
+      (deserialiseStr [decimalInteger] (TProd [T1, TVar 0]) "(both () 2)") `shouldBe` (Just ((), 2))
 
 --    it "deserialise mu" $
 --      (deserialise [Integer] [decimalInteger] (TMu "List" [("Nil", T1), ("Cons", TProd [TVar 1, TVar 0])]) "(inn (right (both 1 (inn (right (both 2 (inn (left ()))))))))")
@@ -62,7 +62,7 @@ testSuite = spec $ do
 --      (Just (Inn (Right (1, Inn (Right (2, Inn (Left ())))))))
 
     it "deserialise nested mu" $
-      (deserialise [] [] (TList `ap` [TNat])
+      (deserialiseStr [] (TList `ap` [TNat])
         ("(inn (right (both (inn (right (inn (right (inn (right (inn (left ())))))))) " ++
          "(inn (right (both (inn (right (inn (right (inn (left ())))))) " ++
          "(inn (right (both (inn (right (inn (left ())))) (inn (left ())))))))))))"))
@@ -70,7 +70,7 @@ testSuite = spec $ do
       (Just $ fromList {tdef=TNat} $ map fromNat [3,2,1])
 
     it "deserialise doubly nested mu specified via partial application" $
-      (deserialise [] [] ((TList `ap` [TList]) `ap` [TNat])
+      (deserialiseStr [] ((TList `ap` [TList]) `ap` [TNat])
         ("(inn (right (both (inn (right (both (inn (right (inn (left ())))) (inn (left ()))))) " ++
          "(inn (right (both (inn (right (both (inn (right (inn (right (inn (left ())))))) (inn (left ()))))) (inn (left ()))))))))"))
         `shouldBe`
@@ -91,3 +91,4 @@ testSuite = spec $ do
     it "round1 mu step" $ roundtrip1 (TMu [("Nil", T1), ("Cons", TProd [(TMu [("Z", T1), ("S", TVar 0)]), TVar 0])]) (Inn (Right ((Inn (Left ()), Inn (Right ((Inn (Right (Inn (Left ()))), Inn (Right ((Inn (Right (Inn (Right (Inn (Left ()))))), Inn (Left ())))))))))))
       `shouldBe` (Just ((Inn (Right ((Inn (Left ()), Inn (Right ((Inn (Right (Inn (Left ()))), Inn (Right ((Inn (Right (Inn (Right (Inn (Left ()))))), Inn (Left ()))))))))))), empty))
 -}
+


### PR DESCRIPTION
Equivalent PR to #227 but for TermParse

Given a specialisation context and parsers for each type in that context we can parse any term that has a specialised representation.