### PR TITLE
Implement partial application

### DIFF
--- a/elba.toml
+++ b/elba.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = []
 
 [dependencies]
-"gallais/idris-tparsec" = { git = "https://github.com/gallais/idris-tparsec/" }
+"gallais/idris-tparsec" = { git = "https://github.com/gallais/idris-tparsec/" , tag = "943c64dfcb4e1582696f68312fad88145dc3a8e4" }
 "HuwCampbell/optparse-idris" = { git = "https://github.com/statebox/optparse-idris" }
 "ziman/idris-bytes" = { git = "https://github.com/statebox/idris-bytes/" }
 "HuwCampbell/idris-lens" = { git = "https://github.com/andrevidela/idris-lens" }
@@ -17,6 +17,8 @@ path = "src"
 mods = [ "Typedefs.Names"
        , "Typedefs.Parse"
        , "Typedefs.Typedefs"
+       , "Typedefs.Idris"
+       , "Typedefs.Library"
        , "Typedefs.TypedefsDecEq"
        , "Typedefs.TermParse"
        , "Typedefs.TermWrite"

--- a/src/Typedefs/Test/TermParseWriteTests.idr
+++ b/src/Typedefs/Test/TermParseWriteTests.idr
@@ -70,11 +70,11 @@ testSuite = spec $ do
       (Just $ fromList {tdef=TNat} $ map fromNat [3,2,1])
 
     it "deserialise doubly nested mu specified via partial application" $
-      (deserialise [] [] ((TList `ap` [TList]) `ap` [TNat])
+      (deserialise [] [] ((TList `ap1` TList) `ap1` TNat)
         ("(inn (right (both (inn (right (both (inn (right (inn (left ())))) (inn (left ()))))) " ++
          "(inn (right (both (inn (right (both (inn (right (inn (right (inn (left ())))))) (inn (left ()))))) (inn (left ()))))))))"))
         `shouldBe`
-       (Just $ fromList {tdef=TList `ap` [TNat]} (map (fromList {tdef=TNat} . map fromNat) [[1],[2]]))
+       (Just $ fromList {tdef=TList `ap1` TNat} (map (fromList {tdef=TNat} . map fromNat) [[1],[2]]))
 
 {-
   describe "Binary serialisation/deserialisation" $ do


### PR DESCRIPTION
Add a new function `ap1` which takes a single TDef as argument and return a TDef which substitutes this TDef and returns a new TDef with the appropriate arity