### PR TITLE
port typedefs to idris2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.o
 *.hi
 
+build/
 target/
 elba.lock
 

--- a/idris2.ipkg
+++ b/idris2.ipkg
@@ -1,0 +1,12 @@
+package typedefs-core
+
+modules = Typedefs
+        , Typedefs.Names
+        , Typedefs.Idris
+        , Typedefs.TermWrite
+        , Typedefs.TermParse
+        , Typedefs.DecEq
+        , Typedefs.Library
+
+sourcedir = "idris2"
+depends = contrib

--- a/idris2/idris2.ipkg
+++ b/idris2/idris2.ipkg
@@ -1,0 +1,12 @@
+package typedefs-core
+
+modules = Typedefs
+        , Typedefs.Names
+        , Typedefs.Idris
+        , Typedefs.TermWrite
+        , Typedefs.TermParse
+        , Typedefs.DecEq
+        , Typedefs.Library
+
+sourcedir = "src"
+depends = contrib

--- a/idris2/src/Typedefs.idr
+++ b/idris2/src/Typedefs.idr
@@ -1,0 +1,424 @@
+module Typedefs
+
+import Data.Fin
+import Data.Nat
+import Data.Vect
+import Data.List
+import Data.List1
+import Data.String
+
+import public Typedefs.Names
+
+%default total
+
+mutual
+  ||| Type definition
+  ||| @n The number of type variables in the type
+  ||| @b A flag to indicate whether the TDef contains unknown references
+  public export
+  data TDef' : (n : Nat) -> (b : Bool) -> Type where
+
+    ||| The empty type
+    T0    :
+          -------------
+            TDef' n b
+
+    ||| The unit type
+    T1    :
+          -------------
+            TDef' n b
+
+    ||| The coproduct type
+    TSum  : {k : Nat} ->
+            Vect (2 + k) (TDef' n b) ->
+          -------------------------------
+            TDef' n b
+
+    ||| The product type
+    TProd : {k : Nat} ->
+            Vect (2 + k) (TDef' n b) ->
+          -------------------------------
+            TDef' n b
+
+    ||| A type variable
+    ||| @i De Bruijn index
+    TVar  : (i : Fin (S n)) ->
+          ----------------------
+            TDef' (S n) b
+
+    ||| Mu
+    TMu   : {k : Nat} ->
+            Vect k (Name, TDef' (S n) b) ->
+          ----------------------------------
+            TDef' n b
+
+    ||| Application of a named type to a vector of arguments.
+    TApp  : {k : Nat} -> TNamed' k b -> Vect k (TDef' n b) -> TDef' n b
+
+    ||| A resolved reference to an unknown typedef
+    RRef  : Fin (S n) ->
+          ---------------------
+            TDef' (S n) False
+
+    ||| A free reference to an unknown typedef
+    FRef  : Name ->
+          ----------------
+            TDef' n True
+
+  ||| Named type definition.
+  ||| @n The number of type variables in the type.
+  public export
+  record TNamed' (n : Nat) (b : Bool) where
+    constructor TName
+    name : Name
+    def  : TDef' n b
+
+public export
+SpecType : {n : Nat} -> {b : Bool} -> TDef' n b -> Type
+SpecType _ {b = True} = Name
+SpecType _ {b = False} {n} = Fin n
+
+public export
+SpecType' : Nat -> Bool -> Type
+SpecType' _ True = Name
+SpecType' n False = Fin n
+
+||| TDef with variables
+public export
+TDef : Nat -> Type
+TDef n = TDef' n True
+
+||| TNamed with variables
+public export
+TNamed : Nat -> Type
+TNamed n = TNamed' n True
+
+||| Resolved TDef
+public export
+TDefR : Nat -> Type
+TDefR n = TDef' n False
+
+||| Resolved TNamed
+public export 0
+TNamedR : Nat -> Type
+TNamedR n = TNamed' n False
+
+public export
+record TopLevelDef where
+  constructor MkTopLevelDef
+  specialized : List String
+  typedefs : List1 (n ** TNamedR n)
+
+||| Generate `[TVar 0, ..., TVar (n-1)]`.
+public export
+idVars : (n : Nat) -> Vect n (TDef' n b)
+idVars Z = []
+idVars (S n) = map TVar range
+
+||| Apply a `TNamed` to the variable list `[TVar 0, ..., TVar (n-1)]`. Semantically, this is the same as
+||| doing nothing, but it allows us to embed a named definition in a regular `TDef`.
+public export
+wrap : (n : Nat) -> TNamed' n b -> TDef' n b
+wrap n tn = TApp tn (idVars n)
+
+||| Alias one `TNamed` with a new name. Note: this is not the same as naming the underlying `TDef` again.
+public export
+alias : {n : Nat} -> Name -> TNamed' n b -> TNamed' n b
+alias name tn = TName name (wrap n tn)
+
+-- Surrounding character functions
+export
+parens : String -> String
+parens "" = ""
+parens s = "(" ++ s ++ ")"
+
+export
+parens' : String -> String
+parens' s = if " " `isInfixOf` s then "(" ++ s ++ ")" else s
+
+export
+curly : String -> String
+curly "" = ""
+curly s = "{" ++ s ++ "}"
+
+export
+square : String -> String
+square "" = ""
+square s = "[" ++ s ++ "]"
+
+||| Generate the canonical name of a closed type.
+public export
+makeName : TDef' 0 b -> Name
+makeName  T0                     = "void"
+makeName  T1                     = "unit"
+makeName (TSum ts)               = "sum" ++ parens (concat . intersperse "," . map (assert_total makeName) $ ts)
+makeName (TProd ts)              = "prod" ++ parens (concat . intersperse "," . map (assert_total makeName) $ ts)
+makeName (TMu cases)             = concatMap fst cases
+makeName (TApp f xs)             = name f ++ parens (concat . intersperse "," . map (assert_total makeName) $ xs)
+makeName (RRef i)    {b = False} impossible
+makeName (FRef i)    {b = True } = "ref"
+
+-- Dealing with variables
+
+public export
+Ren : Nat -> Nat -> Type
+Ren n m = Fin n -> Fin m
+
+public export
+ext : Ren n m -> Ren (S n) (S m)
+ext s  FZ    = FZ
+ext s (FS x) = FS (s x)
+
+public export
+rename : {m : Nat} -> Ren n m -> TDef' n b ->  TDef' m b
+rename r          T0                     = T0
+rename r          T1                     = T1
+rename r         (TSum ts)               = assert_total $ TSum $ map (rename r) ts
+rename r         (TProd ts)              = assert_total $ TProd $ map (rename r) ts
+rename r         (TMu cs)                = assert_total $ TMu $ map (map $ rename (ext r)) cs
+rename r         (TApp f xs)             = assert_total $ TApp f $ map (rename r) xs
+rename r {m=Z}   (RRef i)    {b = False} = absurd $ r i
+rename r {m=S m} (RRef i)    {b = False} = RRef $ r i
+rename r {m=Z}   (TVar v)                = absurd $ r v
+rename r {m=S m} (TVar v)                = TVar $ r v
+rename r         (FRef i)    {b = True}  = FRef i
+
+||| Add 1 to all de Bruijn-indices in a `TDef`.
+||| Useful for including a predefined open definition into a `TMu` without touching the recursive variable.
+public export
+shiftVars : {n : Nat} -> TDef' n a -> TDef' (S n) a
+shiftVars = rename FS
+
+||| Get a list of the De Bruijn indices that are actually used in a `TDef`.
+||| /!\ TDefR n will count resolved references as variables /!\
+public export
+getUsedIndices : TDef' n a -> List (Fin n)
+getUsedIndices T0          = []
+getUsedIndices T1          = []
+getUsedIndices (TSum xs)   = assert_total $ List.nub $ concatMap getUsedIndices xs
+getUsedIndices (TProd xs)  = assert_total $ List.nub $ concatMap getUsedIndices xs
+getUsedIndices (TVar i)    = [i]
+getUsedIndices (TMu xs)    = assert_total $ List.nub $ concatMap ((concatMap weedOutZero) . getUsedIndices . snd) xs
+  where weedOutZero : Fin (S n) -> List (Fin n)
+        weedOutZero FZ     = []
+        weedOutZero (FS i) = [i]
+getUsedIndices (TApp f xs) =
+  let fUses = assert_total $ getUsedIndices (def f)
+   in nub $ concatMap (assert_total getUsedIndices) $ map (flip index xs) fUses
+getUsedIndices (RRef i)    {a = False} = [i]
+getUsedIndices (FRef i)    {a = True } = []
+
+||| Filter out the entries in an argument vector that are actually referred to by a `TDef`.
+public export
+getUsedVars : Vect n a -> (td : TDef' n b) -> Vect (List.length (getUsedIndices td)) a
+getUsedVars e td = map (flip index e) (fromList $ getUsedIndices td)
+
+||| Substitute all variables in a `TDef` with a vector of arguments.
+||| This also replaces resolved references
+public export
+ap : {m : Nat} -> TDef' n b -> Vect n (TDef' m b) -> TDef' m b
+ap  T0         _                = T0
+ap  T1         _                = T1
+ap (TSum ts)   args             = assert_total $ TSum $ map (flip ap args) ts
+ap (TProd ts)  args             = assert_total $ TProd $ map (flip ap args) ts
+ap (TVar v)    args             = index v args
+ap (TMu cs)    args             = assert_total $ TMu $ map (map (flip ap (TVar FZ :: map shiftVars args))) cs
+ap (TApp f xs) args             = assert_total $ def f `ap` (map (flip ap args) xs)
+ap (RRef i)    args {b = False} = Vect.index i args
+ap (FRef i)    args {b = True } = FRef i
+
+||| Substitute all variables in a `TNamed` with a vector of *closed* arguments.
+public export
+apN : TNamed' n a -> Vect n (TDef' 0 a) -> TNamed' 0 a
+apN (TName name body) ts =
+  let vars = getUsedVars ts body
+      newName = parens (concat . intersperse "," . map makeName $ vars)
+   in TName
+        (name ++ newName)
+        (body `ap` ts)
+
+-------------------------------------------------------------------------------
+-- Weakenings                                                                --
+-------------------------------------------------------------------------------
+
+public export
+weakenLTE : Fin n -> LTE n m -> Fin m
+weakenLTE  FZ     LTEZero impossible
+weakenLTE (FS _)  LTEZero impossible
+weakenLTE  FZ    (LTESucc y) = FZ
+weakenLTE (FS x) (LTESucc y) = FS $ Typedefs.weakenLTE x y
+
+mutual
+  ||| Increase the type index representing the number of variables accessible
+  ||| to a `TDef`, without actually changing the variables that are used by it.
+  |||
+  ||| @m The new amount of variables.
+  public export
+  weakenTDef : TDef' n a -> (m : Nat) -> LTE n m -> TDef' m a
+  weakenTDef T0             _    _   = T0
+  weakenTDef T1             _    _   = T1
+  weakenTDef (TSum xs)      m    prf = TSum $ weakenTDefs xs m prf
+  weakenTDef (TProd xs)     m    prf = TProd $ weakenTDefs xs m prf
+  weakenTDef (TVar _)       Z    prf = absurd prf
+  weakenTDef (TVar i)    (S m)   prf = TVar $ Fin.weakenLTE i prf
+  weakenTDef (TMu xs)       m    prf = TMu $ weakenNTDefs xs (S m) (LTESucc prf)
+  weakenTDef (TApp f xs)    m    prf = TApp f $ weakenTDefs xs m prf
+  weakenTDef (RRef x)    (S m)   prf {a = False} = RRef $ Fin.weakenLTE x prf
+  weakenTDef (FRef x)       m    prf {a = True } = FRef x
+
+  public export
+  weakenTDefs : Vect k (TDef' n a) -> (m : Nat) -> LTE n m -> Vect k (TDef' m a)
+  weakenTDefs []      _ _   = []
+  weakenTDefs (x::xs) m lte = weakenTDef x m lte :: weakenTDefs xs m lte
+
+  public export
+  weakenNTDefs : Vect k (Name, TDef' n a) -> (m : Nat) -> LTE n m -> Vect k (Name, TDef' m a)
+  weakenNTDefs []          _ _   = []
+  weakenNTDefs ((n,x)::xs) m lte = (n, weakenTDef x m lte) :: weakenNTDefs xs m lte
+
+||| Increase the type index representing the number of variables accessible
+||| to a `TNamed`, without actually changing the variables that are used by it.
+|||
+||| @m The new amount of variables.
+public export
+weakenTNamed : TNamed' n a -> (m : Nat) -> LTE n m -> TNamed' m a
+weakenTNamed (TName n t) m prf = TName n (weakenTDef t m prf)
+
+-------------------------------------------------------------------------------
+-- Equality                                                                  --
+-------------------------------------------------------------------------------
+
+vectEq : Eq a => Vect n a -> Vect m a -> Bool
+vectEq []      []      = True
+vectEq (x::xs) (y::ys) = x == y && vectEq xs ys
+vectEq _       _       = False
+
+{-
+mutual
+
+  heteroEq : {n, m : Nat} -> TDef' n a -> TDef' m a -> Bool
+  heteroEq {n} {m} tn tm with (cmp n m)
+    heteroEq {n = n} {m = (plus _ (S y))} tn tm | (CmpLT y) = tm == (weakenTDef tn _ (lteAddRight n))
+    heteroEq {n = m} {m = m} tn tm | CmpEQ = tn == (weakenTDef tm _ (lteAddRight m))
+    heteroEq {n = (plus m (S x))} {m = m} tn tm | (CmpGT x) = tn == tm
+
+  heteroEq {-n} {m-} tn tm with (cmp n m)
+    heteroEq {-n} {m-} tn tm | (CmpLT y) = False --tm == (weakenTDef tn _ (lteAddRight n)) -- or should this be `False`?
+    heteroEq {-n} {m-} tn tm | (CmpGT x) = False --tn == (weakenTDef tm _ (lteAddRight m)) -- or should this be `False`?
+    heteroEq {-n} {m-} tn tm | (CmpEQ)   = False -- tn == tm
+
+  heteroEqNamed : {n : Nat} -> {m : Nat} -> TNamed' n a -> TNamed' m a -> Bool
+  heteroEqNamed (TName name t) (TName name' t') = name == name' && heteroEq t t'
+
+  implementation Eq (TDef' n a) where
+    (==) T0          T0            {a = a}     = True
+    (==) T1          T1            {a = a}     = True
+    (==) (TSum xs)   (TSum xs')    {a = a}     = assert_total $ vectEq xs xs'
+    (==) (TProd xs)  (TProd xs')   {a = a}     = assert_total $ vectEq xs xs'
+    (==) (TVar i)    (TVar i')     {a = a}     = i == i'
+    (==) (TMu xs)    (TMu xs')     {a = a}     = assert_total $ vectEq xs xs'
+    (==) (TApp f xs) (TApp f' xs') {a = a}     = assert_total $ heteroEqNamed f f' && vectEq xs xs'
+    (==) (RRef n)    (RRef n')     {a = False} = n == n'
+    (==) (FRef n)    (FRef n')     {a = False} impossible
+    (==) (RRef n)    (RRef n')     {a = True}  impossible
+    (==) (FRef n)    (FRef n')     {a = True}  = n == n'
+    (==) _           _             {a = a} = False
+
+implementation Eq (TNamed' n a) where
+  (TName n t) == (TName n' t')       = n == n' && t == t'
+  -}
+
+-------------------------------------------------------------------------------
+-- Meta                                                                      --
+-------------------------------------------------------------------------------
+
+pow : Nat -> TDef' n a -> TDef' n a
+pow  Z        _ = T1
+pow (S Z)     a = a
+pow (S (S n)) a = TProd (a :: a :: replicate n a)
+
+powN : (n : Nat) -> TNamed' n a -> TDef' n a
+powN n tn = pow n (wrap n tn)
+
+-- TODO add to stdlib?
+minusPlus : (n, m : Nat) -> LTE n m -> (m `minus` n) + n = m
+minusPlus  Z     m    _   = rewrite minusZeroRight m in
+                            plusZeroRightNeutral m
+minusPlus (S _)  Z    lte = absurd lte
+minusPlus (S n) (S m) lte = rewrite sym $ plusSuccRightSucc (m `minus` n) n in
+                            ?huh --cong _ $ minusPlus n m (fromLteSucc lte)
+
+-------------------------------------------------------------------------------
+-- Printing                                                                  --
+-------------------------------------------------------------------------------
+
+mutual
+  showTDef : TDef' n a -> String
+  showTDef T0          = "0"
+  showTDef T1          = "1"
+  showTDef (TSum xs)   = parens $ showOp "+" xs
+  showTDef (TProd xs)  = parens $ showOp "*" xs
+  showTDef (TVar x)    = curly $ show $ finToNat x
+  showTDef (TMu ms)    = parens $ "mu " ++ square (showNTDefs ms)
+  showTDef (TApp f []) = name f
+  showTDef (TApp f xs) = parens $ concat (intersperse " " (name f :: map (assert_total showTDef) xs))
+  showTDef (FRef n)    {a = True} = n
+  showTDef (RRef n)    {a = False} = curly $ show $ finToNat n
+
+  showOp : String -> Vect k (TDef' n a) -> String
+  showOp _  []         = ""
+  showOp _  [x]        = showTDef x
+  showOp op (x::y::ys) = showTDef x ++ " " ++ op ++ " " ++ assert_total (showOp op (y::ys))
+
+  showNTDefs : Vect k (Name, TDef' n a) -> String
+  showNTDefs []          = ""
+  showNTDefs [(n,x)]     = n ++ ": " ++ assert_total (showTDef x)
+  showNTDefs ((n,x)::xs) = n ++ ": " ++ assert_total (showTDef x) ++ ", " ++ assert_total (showNTDefs xs)
+
+showTNamed : TNamed' n a -> String
+showTNamed (TName n t) = parens $ n ++ " := " ++ showTDef t
+
+Show (TDef' n a) where
+  show = showTDef
+
+Show (TNamed' n a) where
+  show = showTNamed
+
+-- Debug ----
+
+-- we use a named implementation of `Show (Fin n)` to avoid possible conflicts
+[finSimpleShow] Show (Fin k) where
+  show = show . finToNat
+
+mutual
+  debugTDefVect : Vect k (TDef' n b) -> String
+  debugTDefVect []        = "[]"
+  debugTDefVect (x :: xs) = assert_total $
+    square $ foldr (\elem, acc => acc ++ ", " ++ debugTDef elem) (debugTDef x) xs
+
+  debugMu : Vect k (Name, TDef' (S n) b) -> String
+  debugMu []        = "[]"
+  debugMu (x :: xs) = assert_total $
+    square $ foldr (\elem, acc => acc ++ ", " ++ debugNamedMu elem) (debugNamedMu x) xs
+    where
+      debugNamedMu : (Name, TDef' (S n) b) -> String
+      debugNamedMu (name, tdef) = parens $ show name ++ ", " ++ debugTDef tdef
+
+  ||| prints a faithful representation of the AST of a TDef
+  debugTDef : TDef' n b -> String
+  debugTDef T0          = "T0"
+  debugTDef T1          = "T1"
+  debugTDef (TSum  xs)  = "TSum " ++ debugTDefVect xs
+  debugTDef (TProd xs)  = "TProd " ++ debugTDefVect xs
+  debugTDef (TVar x)    = "TVar " ++ show @{finSimpleShow} x
+  debugTDef (TMu ms)    = "TMu " ++ debugMu ms
+  debugTDef (TApp f xs) = "TApp (" ++ debugTNamed f ++ ", " ++ debugTDefVect xs ++ ")"
+  debugTDef (FRef n)    = "FRef " ++ show n
+  debugTDef (RRef n)    = "RRef " ++ show @{finSimpleShow} n
+
+  ||| prints a faithful representation of the AST of a TNamed
+  debugTNamed : TNamed' n b -> String
+  debugTNamed (TName name tdef) = "TName (" ++ show name ++ ", " ++ debugTDef tdef ++ ")"
+
+{-
+-}

--- a/idris2/src/Typedefs/DecEq.idr
+++ b/idris2/src/Typedefs/DecEq.idr
@@ -1,0 +1,253 @@
+module Typedefs.DecEq
+
+import public Decidable.Equality
+import Data.Vect
+import Data.Nat
+import Typedefs.Names
+import Typedefs
+
+%default total
+-- injectivity proofs
+
+tsumInj : {a : Vect (2+n) (TDef' k bool)} -> {b : Vect (2+m) (TDef' k bool)} -> TSum a ~=~ TSum b -> a ~=~ b
+tsumInj Refl = Refl
+
+tprodInj : {a : Vect (2+n) (TDef' k bool)} -> {b : Vect (2+m) (TDef' k bool)} -> TProd a ~=~ TProd b -> a ~=~ b
+tprodInj Refl = Refl
+
+tvarInj : {i, j : Fin (S n)} -> TVar i = TVar j -> i = j
+tvarInj Refl = Refl
+
+tmuInj : {a : Vect k1 (Name, TDef' (S n) bool)} -> {b : Vect k2 (Name, TDef' (S m) bool)} -> TMu a = TMu b -> a = b
+tmuInj Refl = Refl
+
+tappInjNamed : {t : TNamed' k bool} -> {u : TNamed' k1 bool} -> {a : Vect k (TDef' n bool)} ->
+               {b : Vect k1 (TDef' m bool)} -> TApp t a = TApp u b -> t = u
+tappInjNamed Refl = Refl
+
+tappInjVect : {t : TNamed' k b} -> {u : TNamed' k1 b} -> {a : Vect k (TDef' n b)} ->
+              {c : Vect k1 (TDef' m b)} -> TApp t a = TApp u c -> a = c
+tappInjVect Refl = Refl
+
+vectInj : {xs : Vect n a} -> {xs' : Vect m a} -> xs = xs' -> n = m
+vectInj Refl = Refl
+
+tnameInjName : {name, name' : String} -> TName name def = TName name' def' -> name = name'
+tnameInjName Refl = Refl
+
+tnameInjDef : {def, def' : TDef' k b} -> TName name def = TName name' def' -> def = def'
+tnameInjDef Refl = Refl
+
+frefInj : (FRef r = FRef r') -> r = r'
+frefInj Refl = Refl
+
+-- inequality proofs
+
+t0NotT1 : T0 = T1 -> Void
+t0NotT1 Refl impossible
+
+t0NotTSum : T0 = TSum a -> Void
+t0NotTSum Refl impossible
+
+t0NotTProd : T0 = TProd a -> Void
+t0NotTProd Refl impossible
+
+t0NotTVar : T0 = TVar a -> Void
+t0NotTVar Refl impossible
+
+t0NotTMu : T0 = TMu a -> Void
+t0NotTMu Refl impossible
+
+t0NotTApp : T0 = TApp n a -> Void
+t0NotTApp Refl impossible
+
+t0NotRRef : T0 = RRef r -> Void
+t0NotRRef Refl impossible
+
+t0NotFRef : T0 = FRef r -> Void
+t0NotFRef Refl impossible
+
+t1NotTSum : T1 = TSum a -> Void
+t1NotTSum Refl impossible
+
+t1NotTProd : T1 = TProd a -> Void
+t1NotTProd Refl impossible
+
+t1NotTVar : T1 = TVar a -> Void
+t1NotTVar Refl impossible
+
+t1NotTMu : T1 = TMu a -> Void
+t1NotTMu Refl impossible
+
+t1NotTApp : T1 = TApp n a -> Void
+t1NotTApp Refl impossible
+
+t1NotRRef : T1 = RRef r -> Void
+t1NotRRef Refl impossible
+
+t1NotFRef : T1 = FRef r -> Void
+t1NotFRef Refl impossible
+
+tSumNotTProd : TSum a = TProd b -> Void
+tSumNotTProd Refl impossible
+
+tSumNotTVar : TSum a = TVar b -> Void
+tSumNotTVar Refl impossible
+
+tSumNotTMu : TSum a = TMu b -> Void
+tSumNotTMu Refl impossible
+
+tSumNotTApp : TSum a = TApp n b -> Void
+tSumNotTApp Refl impossible
+
+tSumNotRRef : TSum a = RRef r -> Void
+tSumNotRRef Refl impossible
+
+tSumNotFRef : TSum a = FRef r -> Void
+tSumNotFRef Refl impossible
+
+tProdNotTVar : TProd a = TVar b -> Void
+tProdNotTVar Refl impossible
+
+tProdNotTMu : TProd a = TMu b -> Void
+tProdNotTMu Refl impossible
+
+tProdNotTApp : TProd a = TApp n b -> Void
+tProdNotTApp Refl impossible
+
+tProdNotRRef : TProd a = RRef r -> Void
+tProdNotRRef Refl impossible
+
+tProdNotFRef : TProd a = FRef r -> Void
+tProdNotFRef Refl impossible
+
+tVarNotTMu : TVar a = TMu b -> Void
+tVarNotTMu Refl impossible
+
+tVarNotTApp : TVar a = TApp n b -> Void
+tVarNotTApp Refl impossible
+
+tVarNotRRef : TVar a = RRef r -> Void
+tVarNotRRef Refl impossible
+
+tVarNotFRef : TVar a = FRef r -> Void
+tVarNotFRef Refl impossible
+
+tMuNotTApp : TMu a = TApp n b -> Void
+tMuNotTApp Refl impossible
+
+tMuNotRRef : TMu a = RRef r -> Void
+tMuNotRRef Refl impossible
+
+tMuNotFRef : TMu a = FRef r -> Void
+tMuNotFRef Refl impossible
+
+tAppNotRRef : TApp n t = RRef r -> Void
+tAppNotRRef Refl impossible
+
+tAppNotFRef : TApp n t = FRef r -> Void
+tAppNotFRef Refl impossible
+
+-- decidable equality proofs
+
+mutual
+  public export
+  DecEq (TDef' n v) where
+    decEq T0              T0                   = Yes Refl
+    decEq T1              T1                   = Yes Refl
+    decEq (TSum {k} xs)   (TSum {k=k2} xs')    with (assert_total $ decEq k k2)
+      decEq (TSum {k} xs) (TSum {k} xs')         | Yes Refl with (assert_total $ decEq xs xs')
+        decEq (TSum {k} xs) (TSum {k} xs)          | Yes Refl | Yes Refl = Yes Refl
+        decEq (TSum {k} xs) (TSum {k} xs')         | Yes Refl | No ctra = No $ ctra . tsumInj
+      decEq (TSum {k} xs) (TSum {k=k2} xs')      | No ctra =
+        No $ ctra . (succInjective k (k2)) . (succInjective (S k) (S k2)) . vectInj . tsumInj
+    decEq (TProd {k} xs)  (TProd {k=k2} xs')   with (assert_total $ decEq k k2)
+      decEq (TProd {k} xs) (TProd {k} xs')       | Yes Refl with (assert_total $ decEq xs xs')
+        decEq (TProd {k} xs) (TProd {k} xs)        | Yes Refl | Yes Refl = Yes Refl
+        decEq (TProd {k} xs) (TProd {k} xs')       | Yes Refl | No ctra = No $ ctra . tprodInj
+      decEq (TProd {k} xs) (TProd {k=k2} xs')    | No ctra = No $ ctra . (succInjective _ _) . (succInjective _ _) . vectInj . tprodInj
+    decEq (TVar i)        (TVar j)             with (assert_total $ decEq i j)
+      decEq (TVar i)        (TVar i)             | Yes Refl = Yes Refl
+      decEq (TVar i)        (TVar j)             | No ctra  = No $ ctra . tvarInj
+    decEq (TMu {k} xs)    (TMu {k=k2} xs')     with (assert_total $ decEq k k2)
+      decEq (TMu {k} xs) (TMu {k} xs')           | Yes Refl with (assert_total $ decEq xs xs')
+        decEq (TMu {k} xs) (TMu {k} xs)            | Yes Refl | Yes Refl = Yes Refl
+        decEq (TMu {k} xs) (TMu {k} xs')           | Yes Refl | No ctra  = No $ ctra . tmuInj
+      decEq (TMu {k} xs) (TMu {k=k2} xs')        | No ctra = No $ ctra . vectInj . tmuInj
+    decEq (TApp {k} f xs) (TApp {k=k2} f' xs') with (assert_total $ decEq k k2)
+      decEq (TApp {k} f xs) (TApp {k} f' xs')    | Yes Refl with (assert_total $ decEq f f')
+        decEq (TApp {k} f xs) (TApp {k} f xs')     | Yes Refl | Yes Refl with (assert_total $ decEq xs xs')
+          decEq (TApp {k} f xs) (TApp {k} f xs)      | Yes Refl | Yes Refl | Yes Refl = Yes Refl
+          decEq (TApp {k} f xs) (TApp {k} f xs')     | Yes Refl | Yes Refl | No ctra  = No $ ctra . tappInjVect
+        decEq (TApp {k} f xs) (TApp {k} f' xs')    | Yes Refl | No ctra  = No $ ctra . tappInjNamed
+      decEq (TApp {k} f xs) (TApp {k=k2} f' xs') | No ctra  = No $ ctra . vectInj . tappInjVect
+    decEq (FRef r)        (FRef r')            with (assert_total $ decEq r r')
+      decEq (FRef r)        (FRef r)             | (Yes Refl) = Yes Refl
+      decEq (FRef r)        (FRef r')            | (No ctra) = No $ ctra . frefInj
+    decEq T0              T1                   = No t0NotT1
+    decEq T0              (TSum xs)            = No t0NotTSum
+    decEq T0              (TProd xs)           = No t0NotTProd
+    decEq T0              (TVar i)             = No t0NotTVar
+    decEq T0              (TMu xs)             = No t0NotTMu
+    decEq T0              (TApp x xs)          = No t0NotTApp
+    decEq T0              (FRef _)             = No t0NotFRef
+    decEq T1              T0                   = No $ negEqSym t0NotT1
+    decEq T1              (TSum xs)            = No t1NotTSum
+    decEq T1              (TProd xs)           = No t1NotTProd
+    decEq T1              (TVar i)             = No t1NotTVar
+    decEq T1              (TMu xs)             = No t1NotTMu
+    decEq T1              (TApp x xs)          = No t1NotTApp
+    decEq T1              (FRef x)             = No t1NotFRef
+    decEq (TSum xs)       T0                   = No $ negEqSym t0NotTSum
+    decEq (TSum xs)       T1                   = No $ negEqSym t1NotTSum
+    decEq (TSum xs)       (TProd ys)           = No tSumNotTProd
+    decEq (TSum xs)       (TVar i)             = No tSumNotTVar
+    decEq (TSum xs)       (TMu ys)             = No tSumNotTMu
+    decEq (TSum xs)       (TApp x ys)          = No tSumNotTApp
+    decEq (TSum xs)       (FRef x)             = No tSumNotFRef
+    decEq (TProd xs)      T0                   = No $ negEqSym t0NotTProd
+    decEq (TProd xs)      T1                   = No $ negEqSym t1NotTProd
+    decEq (TProd xs)      (TSum ys)            = No $ negEqSym tSumNotTProd
+    decEq (TProd xs)      (TVar i)             = No tProdNotTVar
+    decEq (TProd xs)      (TMu ys)             = No tProdNotTMu
+    decEq (TProd xs)      (TApp x ys)          = No tProdNotTApp
+    decEq (TProd xs)      (FRef x)             = No tProdNotFRef
+    decEq (TVar i)        T0                   = No $ negEqSym t0NotTVar
+    decEq (TVar i)        T1                   = No $ negEqSym t1NotTVar
+    decEq (TVar i)        (TSum xs)            = No $ negEqSym tSumNotTVar
+    decEq (TVar i)        (TProd xs)           = No $ negEqSym tProdNotTVar
+    decEq (TVar i)        (TMu xs)             = No tVarNotTMu
+    decEq (TVar i)        (TApp x xs)          = No tVarNotTApp
+    decEq (TVar i)        (FRef x)             = No tVarNotFRef
+    decEq (TMu xs)        T0                   = No $ negEqSym t0NotTMu
+    decEq (TMu xs)        T1                   = No $ negEqSym t1NotTMu
+    decEq (TMu xs)        (TSum ys)            = No $ negEqSym tSumNotTMu
+    decEq (TMu xs)        (TProd ys)           = No $ negEqSym tProdNotTMu
+    decEq (TMu xs)        (TVar i)             = No $ negEqSym tVarNotTMu
+    decEq (TMu xs)        (TApp x ys)          = No tMuNotTApp
+    decEq (TMu xs)        (FRef x)             = No tMuNotFRef
+    decEq (TApp x xs)     T0                   = No $ negEqSym t0NotTApp
+    decEq (TApp x xs)     T1                   = No $ negEqSym t1NotTApp
+    decEq (TApp x xs)     (TSum ys)            = No $ negEqSym tSumNotTApp
+    decEq (TApp x xs)     (TProd ys)           = No $ negEqSym tProdNotTApp
+    decEq (TApp x xs)     (TVar i)             = No $ negEqSym tVarNotTApp
+    decEq (TApp x xs)     (TMu ys)             = No $ negEqSym tMuNotTApp
+    decEq (TApp x xs)     (FRef y)             = No tAppNotFRef
+    decEq (FRef x)      T0                     = No $ negEqSym t0NotFRef
+    decEq (FRef x)      T1                     = No $ negEqSym t1NotFRef
+    decEq (FRef x)      (TSum xs)              = No $ negEqSym tSumNotFRef
+    decEq (FRef x)      (TProd xs)             = No $ negEqSym tProdNotFRef
+    decEq (FRef x)      (TVar i)               = No $ negEqSym tVarNotFRef
+    decEq (FRef x)      (TMu xs)               = No $ negEqSym tMuNotFRef
+    decEq (FRef x)      (TApp y xs)            = No $ negEqSym tAppNotFRef
+    decEq _ _ = No $ believe_me
+
+  DecEq (TNamed' n b) where
+    decEq (TName name def) (TName name' def') with (decEq name name')
+      decEq (TName name def) (TName name def')  | Yes Refl with (decEq def def')
+        decEq (TName name def) (TName name def)   | Yes Refl | Yes Refl = Yes Refl
+        decEq (TName name def) (TName name def')  | Yes Refl | No ctra = No $ ctra . tnameInjDef
+      decEq (TName name def) (TName name' def') | No ctra  = No $ ctra . tnameInjName
+
+{-
+-}

--- a/idris2/src/Typedefs/DependentLookup.idr
+++ b/idris2/src/Typedefs/DependentLookup.idr
@@ -1,0 +1,33 @@
+module Typedefs.DependentLookup
+
+import public Data.Vect
+import public Decidable.Equality
+import public Data.Vect.Elem
+
+%default total
+
+||| Lookup for maps with a shared index
+public export
+depLookup : DecEq t => {w : t} -> {0 f, g : t -> Type} -> DecEq (f w) =>
+             (vs : Vect n (v : t ** (f v, g v))) -> f w ->
+             Maybe (a : f w ** b : g w ** Elem (w ** (a, b)) vs)
+depLookup [] item = Nothing -- Not found
+depLookup ((n ** (key, val)) :: xs) item {w} with (decEq w n)
+  -- if indices don't match then values can't possibly match since they have different type
+  depLookup ((n ** (key, val)) :: xs) item {w = w} | (No contra) =
+    do (a ** b ** prf) <- depLookup xs item
+       pure (a ** b ** There prf)
+  depLookup ((n ** (key, val)) :: xs) item {w = n} | (Yes Refl) with (decEq key item)
+    depLookup ((n ** (item, val)) :: xs) item {w = n} | (Yes Refl) | (Yes Refl) =
+      -- Index and Value match, return
+      Just (item ** val ** Here {x=(n ** (item, val))})
+    depLookup ((n ** (key, val)) :: xs) item {w = n} | (Yes Refl) | (No contra) =
+      -- Index match but values differ
+      do (a ** b ** prf) <- depLookup xs item
+         pure (a ** b ** There prf)
+
+public export
+depLookupNil : DecEq t => {w : t} -> {f, g : t -> Type} -> {fkey : f w} ->
+               DecEq (f w) =>
+               depLookup {g} [] fkey = Nothing
+depLookupNil = Refl

--- a/idris2/src/Typedefs/Idris.idr
+++ b/idris2/src/Typedefs/Idris.idr
@@ -1,0 +1,298 @@
+module Typedefs.Idris
+
+import Data.Vect
+
+import Typedefs.Names
+import Typedefs
+import public Typedefs.DependentLookup
+import public Typedefs.DecEq
+
+%default total
+
+public export
+TypeConstructor : Nat -> Type
+TypeConstructor Z = Type
+TypeConstructor (S n) = Type -> TypeConstructor n
+
+public export 0
+ApplyVect : TypeConstructor n -> (0 _ : Vect n Type) -> Type
+ApplyVect c [] = c
+ApplyVect c (x :: xs) {n = S k} = ApplyVect (c x) xs
+
+||| A mapping from TDef to idris Type constructor
+public export
+SpecialList : Nat -> Type
+SpecialList n = Vect n (v ** (TDefR v, TypeConstructor v))
+
+public export
+args : {k : Nat} -> Vect k (String, TDef' (S n) a) -> TDef' (S n) a
+args []                 = T0
+args [(_,m)]            = m
+args ((_,m)::(_,l)::ms) = TSum (m :: l :: map snd ms)
+
+public export
+ReverseVect : {n : Nat} -> (mkType : Vect n Type -> Type) -> TypeConstructor n
+ReverseVect mkType {n = Z} = mkType []
+ReverseVect mkType {n = (S k)} = \arg => ReverseVect (popHead mkType arg)
+  where
+    popHead : (Vect (S n) Type -> Type) -> Type -> Vect n Type -> Type
+    popHead f t ts = f (t :: ts)
+
+mutual
+  public export
+  data Mu' : {n : Nat} -> (sp : SpecialList l) -> (tvars : Vect n Type) -> TDef' (S n) a -> Type where
+    Inn : Ty' sp (Mu' sp tvars m :: tvars) m -> Mu' sp tvars m
+
+  public export 0
+  Tnary' : {n : Nat} -> (sp : SpecialList l) -> (tvars : Vect n Type) -> Vect (2 + k) (TDefR n) -> (Type -> Type -> Type) -> Type
+  Tnary' sp tvars [x, y]              c = c (Ty' sp tvars x) (Ty' sp tvars y)
+  Tnary' sp tvars (x :: y :: z :: zs) c = c (Ty' sp tvars x) (Tnary' sp tvars (y :: z :: zs) c)
+
+  ||| Interpret a TDef into an Idris type
+  |||
+  ||| The replacement mapping can only replace types in Mu or App Position.
+  ||| Products, Sums, 0, 1 and variables are never replaced.
+  |||
+  ||| @sp : The mapping between TDefs and the specialised version as an Idris type
+  ||| @tvars : The list of types that will be used to fill all free variables
+  public export 0
+  Ty' : {n : Nat} -> (sp : SpecialList l) -> (tvars : Vect n Type) ->  TDefR n -> Type
+  Ty' sp tvars T0             = Void
+  Ty' sp tvars T1             = Unit
+  Ty' sp tvars (TSum xs) {n}  = assert_total $ Tnary' sp tvars xs Either
+  Ty' sp tvars (TProd xs) {n} = assert_total $ Tnary' sp tvars xs Pair
+  Ty' sp tvars (TVar v)       = Vect.index v tvars
+  Ty' sp tvars (RRef i)       = Vect.index i tvars
+  Ty' sp tvars (TMu m) = case (depLookup sp (TMu m)) of
+    Nothing => Mu' sp tvars (args m)
+    Just (_ ** constr ** prf) => ApplyVect constr tvars
+
+  -- For application we first make a lookup in our mapping from TDef to Type constructors
+  Ty' sp tvars (TApp name xs) with (depLookup sp name.def)
+    -- If we can't find anything, simply apply the type normally
+    Ty' sp tvars (TApp name xs) | Nothing = assert_total $ Ty' sp tvars $ name.def `ap` xs
+    -- If we find a match, check the length of the arguments match the arity of the type constructor
+    -- we found.
+    Ty' sp tvars (TApp name xs) | Just (arity ** constr ** prf) =
+        let args = map (assert_total $ Ty' sp tvars) xs in ApplyVect constr args
+
+-- extractMu : {n,k : Nat} -> {sp : SpecialList l} -> {0 ts : Vect n Type} -> {td : Vect k (String, TDefR (S n))} ->
+--             (prf : depLookup sp (TMu td) = Nothing) ->
+--             Ty' sp ts (TMu td) -> Ty' sp (Ty' [] ts (TMu td) :: ts) (args td)
+-- extractMu Refl x = ?extractMu_rhs
+
+-- for some reason this property does not reduce in `TermWrite.idr` even after a `with (depLookup [] (TMu td))`
+public export
+TyMuPrf : {n, k : Nat} -> {ts : Vect n Type} -> (td : Vect k (String, TDefR (S n) )) -> Ty' [] ts (TMu td) = Mu' [] ts (args td)
+TyMuPrf td = believe_me $ Refl {x=Mu' [] ts (args td)}
+
+public export 0
+Ty : {n : Nat} -> (tvars : Vect n Type) -> TDefR n -> Type
+Ty = Ty' []
+
+public export 0
+Tnary : {n : Nat} -> Vect n Type -> Vect (2 + k) (TDefR n) -> (Type -> Type -> Type) -> Type
+Tnary tvars tds op = Tnary' [] tvars tds op
+
+public export
+Mu : {n : Nat} -> Vect n Type -> TDef' (S n) a -> Type
+Mu args td = Mu' [] args td
+
+public export
+Inn' : Ty (Mu tvars m :: tvars) m -> Mu tvars m
+Inn' v = Inn (believe_me v)
+
+Const1 : a -> b -> a
+Const1 v _ = v
+
+Const2 : a -> b -> c -> a
+Const2 v _ _ = v
+
+public export 0
+Const : (n : Nat) -> Type -> Type
+Const Z ty = ty
+Const (S n) ty = forall x. x -> Const n ty
+
+public export
+ConstN : (n : Nat) -> (v : Type) -> TypeConstructor n
+ConstN Z ty = ty
+ConstN (S n) ty = \_ => ConstN n ty
+
+||| Converts a typedefs of `n` free variables into a type constructor that expects n arguments
+public export 0
+AlphaTy : {n : Nat} -> (sp : SpecialList l) -> TDefR n -> TypeConstructor n
+AlphaTy sp tdef = ReverseVect (\args =>  Ty' sp args tdef)
+
+public export
+NatSum : {f : Nat -> Type} -> Vect n (k : Nat ** f k) -> Nat
+NatSum [] = Z
+NatSum ((x ** _) :: xs) = x + NatSum xs
+
+public export 0
+constructTypes : (types : Vect n (k ** TypeConstructor k)) -> Vect (NatSum types) Type -> Vect n Type
+constructTypes [] [] = []
+constructTypes ((k ** tc) :: xs) args =
+  let (pre, post) = splitAt k args
+   in ApplyVect tc pre :: constructTypes xs post
+
+||| Given a vector of type constructors and a TDef construct the Idris type
+||| from it using the second vector to instanciate the constructors
+public export 0
+BetaTy : {n : Nat} -> (types : Vect n (k ** TypeConstructor k)) -> TDefR n
+     -> Vect (NatSum types) Type -> Type
+BetaTy types tdef args = Ty' [] (constructTypes types args) tdef
+
+||| Given a list of type constructors fill the holes with them and return a new type constructor
+public export 0
+GammaTy : {n : Nat} -> (types : Vect n (k ** TypeConstructor k)) -> TDefR n
+     -> TypeConstructor (NatSum types)
+GammaTy types tdef = ReverseVect {n=NatSum types} (BetaTy types tdef)
+
+
+---------------------------------------------------------------------------------------------
+-- Lemmas                                                                                  --
+---------------------------------------------------------------------------------------------
+
+-- ||| Since `convertTy` is an identity function it is safe to assume this one is too
+-- 0
+-- convertTy' : Ty' [] ts (TApp f ys) -> Ty' [] ts (ap (def f) ys)
+-- convertTy' x = believe_me x
+--
+-- -- `showTy` just needs a little nudge in the right direction
+-- 0
+-- convertTy : {n : Name} -> Ty' [] v (TApp (TName n def) xs) -> Ty' [] v (def `ap` xs)
+-- convertTy x {def = T0       } = x
+-- convertTy x {def = T1       } = x
+-- convertTy x {def = TSum xs  } = x
+-- convertTy x {def = TProd xs } = x
+-- convertTy x {def = TVar i   } = x
+-- convertTy x {def = TMu xs   } = x
+-- convertTy x {def = TApp y xs} = x
+-- convertTy x {def = RRef y   } = x
+
+-- ||| Convert an `ap` into a `TApp` however the replacement context needs to be empty
+-- convertPrf : Ty' [] v (ap def xs) = Ty' [] v (TApp (TName n def) xs)
+-- convertPrf {def = T0} = Refl
+-- convertPrf {def = T1} = Refl
+-- convertPrf {def = (TSum xs)} = Refl
+-- convertPrf {def = (TProd xs)} = Refl
+-- convertPrf {def = (TVar i)} = Refl
+-- convertPrf {def = (TMu xs)} = Refl
+-- convertPrf {def = (RRef x)} = Refl
+-- convertPrf {def = (TApp x xs)} = Refl
+
+-- TODO we should either finish mu/app cases or save some space by
+-- making both of these into `really_believe_me` one-liners.
+-- This is safe because adding/removing an unused var is a no-op.
+
+-- ignoreShift : {t : TDefR n} -> Ty' sp (var::vars) (shiftVars t) -> Ty' sp vars t
+-- ignoreShift {t=T0}                     ty         = absurd ty
+-- ignoreShift {t=T1}                     ()         = ()
+-- ignoreShift {t=TSum [x,y]}             (Left ty)  = Left $ ignoreShift ty
+-- ignoreShift {t=TSum [x,y]}             (Right ty) = Right $ ignoreShift ty
+-- ignoreShift {t=TSum (x::y::z::ts)}     (Left ty)  = Left $ ignoreShift ty
+-- ignoreShift {t=TSum (x::y::z::ts)}     (Right ty) = Right $ ignoreShift {t=TSum (y::z::ts)} ty
+-- ignoreShift {t=TProd [x,y]}            (ty1,ty2)  = (ignoreShift ty1,ignoreShift ty2)
+-- ignoreShift {t=TProd (x::y::z::ts)}    (ty1,ty2)  = (ignoreShift ty1,ignoreShift {t=TProd (y::z::ts)} ty2)
+-- ignoreShift {t=TMu cs}                  ty        = really_believe_me ty
+-- ignoreShift {t=TApp (TName nam df) xs}  ty        = really_believe_me ty
+-- ignoreShift {t=TVar v}                  ty        = ty
+-- ignoreShift {t=RRef i}                  ty        = ty
+--
+-- addShift : {t : TDefR n} -> Ty' sp vars t -> Ty' sp (var::vars) (shiftVars t)
+-- addShift {t=T0}                      ty        = absurd ty
+-- addShift {t=T1}                     ()         = ()
+-- addShift {t=TSum [x,y]}             (Left ty)  = Left $ addShift ty
+-- addShift {t=TSum [x,y]}             (Right ty) = Right $ addShift ty
+-- addShift {t=TSum (x::y::z::ts)}     (Left ty)  = Left $ addShift ty
+-- addShift {t=TSum (x::y::z::ts)}     (Right ty) = Right $ addShift {t=TSum (y::z::ts)} ty
+-- addShift {t=TProd [x,y]}            (ty1,ty2)  = (addShift ty1,addShift ty2)
+-- addShift {t=TProd (x::y::z::ts)}    (ty1,ty2)  = (addShift ty1,addShift {t=TProd (y::z::ts)} ty2)
+-- addShift {t=TMu cs}                  ty        = really_believe_me ty
+-- addShift {t=TApp (TName nam df) xs}  ty        = really_believe_me ty
+-- addShift {t=TVar v}                  ty        = ty
+-- addShift {t=RRef i}                  ty        = ty
+
+-------------------------------------------------------------------------------
+-- Show                                                                      --
+-------------------------------------------------------------------------------
+
+-- mutual
+--
+--   showMu : (tvars : Vect n (a : Type ** a -> String)) -> (td : TDef' (S n) b)
+--         -> Mu' [] (map DPair.fst tvars) td -> String
+--   showMu tvars td (Inn x) =
+--     let printMu = (Mu' [] (map DPair.fst tvars) td ** assert_total $ showMu tvars td)
+--      in parens' (assert_total $ showTy (printMu::tvars) td x)
+--
+--   ||| Print the content of a TDef provided functions to display Types as strings
+--   ||| @tvars a vector of n functions that map types to their string representation
+--   ||| @td the tdef to show
+--   ||| @x the idris type represented by `td` using `tvars` for free variables
+--   showTy : (tvars : Vect n (a : Type ** a -> String))
+--         -> (td : TDefR n)
+--         -> (x : Ty' [] (map DPair.fst tvars) td)
+--         -> String
+--   showTy                  tvars  T0                          x        impossible
+--   showTy                  tvars  T1                          x        = show x
+--   showTy                  tvars  (TSum [a,b])               (Left x)  = "Left " ++ parens' (showTy tvars a x)
+--   showTy                  tvars  (TSum [a,b])               (Right x) = "Right " ++ parens' (showTy tvars b x)
+--   showTy                  tvars  (TSum (a::b::c::xs))       (Left x)  = "Left " ++ parens' (showTy tvars a x)
+--   showTy                  tvars  (TSum (a::b::c::xs))       (Right x) = "Right " ++ parens' (assert_total $ showTy tvars (TSum (b::c::xs)) x)
+--   showTy   ((a ** showA)::tvars) (TVar FZ)                   x        = showA x
+--   showTy {n=S (S n')} (_::tvars) (TVar (FS i))               x        = showTy {n = S n'} tvars (TVar i) x
+--   showTy                  tvars  (TMu m)                     x        = showMu tvars (args m) x
+--   showTy   ((a ** showA)::tvars) (RRef FZ)                   x        = showA x
+--   showTy {n=S (S n')} (_::tvars) (RRef (FS i))               x        = showTy {n = S n'} tvars (RRef i) x
+--   showTy                  tvars  (TApp (TName name def) xs)  x
+--     = assert_total $ showTy tvars (def `ap` xs) (convertTy x)
+--   showTy {n}              tvars  (TProd xs)                  x
+--     = parens $ concat $ List.intersperse ", " (showProd xs x)
+--     where showProd : (ys : Vect (2 + k) (TDefR n))
+--                   -> Tnary' [] (map DPair.fst tvars) ys Pair -> List String
+--           showProd [a, b]        (x, y) = (showTy tvars a x)::[showTy tvars b y]
+--           showProd (a::b::c::ys) (x, y) = (showTy tvars a x)::showProd (b::c::ys) y
+--
+-- Show (Mu' sp {l=Z} [] td) where
+--   show y {sp=[]} = showMu [] td y
+--
+-- -------------------------------------------------------------------------------
+-- -- Type Equality                                                             --
+-- -------------------------------------------------------------------------------
+-- -- Note: Equality on Types only work when the specialisation context is empty--
+-- -------------------------------------------------------------------------------
+--
+-- mutual
+--
+--   eqMu : (tvars : Vect n (a : Type ** a -> a -> Bool)) -> (td : TDefR (S n)) ->
+--          Mu' [] (map DPair.fst tvars) td -> Mu' [] (map DPair.fst tvars) td  -> Bool
+--   eqMu tvars td (Inn x) (Inn x') =
+--     eqTy ((Mu' [] (map DPair.fst tvars) td ** assert_total $ eqMu tvars td)::tvars) td x x'
+--
+--   eqTy : (tvars : Vect n (a : Type ** a -> a -> Bool)) -> (td : TDefR n) ->
+--          Ty' [] (map DPair.fst tvars) td -> Ty' [] (map DPair.fst tvars) td -> Bool
+--   eqTy tvars T0                    x x'        impossible
+--   eqTy tvars T1                    x x'      = x == x'
+--   eqTy tvars (TSum [a,b])          (Left x)  (Left x') = eqTy tvars a x x'
+--   eqTy tvars (TSum [a,b])          (Right x) (Right x') = eqTy tvars b x x'
+--   eqTy tvars (TSum (a::b::c::xs))  (Left x)  (Left x') = eqTy tvars a x x'
+--   eqTy tvars (TSum (a::b::c::xs))  (Right x) (Right x') = assert_total $ eqTy tvars (TSum (b::c::xs))  x x'
+--   eqTy {n = n} tvars (TProd xs)    x x' = eqProd xs x x'
+--     where eqProd : (ys : Vect (2 + k) (TDefR n))
+--                 -> Tnary' [] (map DPair.fst tvars) ys Pair
+--                 -> Tnary' [] (map DPair.fst tvars) ys Pair -> Bool
+--           eqProd [a, b]        (x, y) (x', y') = (eqTy tvars a x x') && (eqTy tvars b y y')
+--           eqProd (a::b::c::ys) (x, y) (x', y') = (eqTy tvars a x x') && (eqProd (b::c::ys) y y')
+--   eqTy ((a ** eqA)::tvars)     (TVar FZ)         x x' = eqA x x'
+--   eqTy {n = S (S n')} (_::tvars) (TVar (FS i))   x x' = eqTy {n = S n'} tvars (TVar i) x x'
+--   eqTy tvars                     (TMu m)         x x' = eqMu tvars (args m) x x'
+--   eqTy tvars      (TApp (TName name def) xs)     x x' = assert_total $ eqTy tvars (def `ap` xs) (convertTy x) (convertTy x')
+--   eqTy ((a ** eqA)::tvars)       (RRef FZ)       x x' = eqA x x'
+--   eqTy {n = S (S n')} (_::tvars) (RRef (FS i))   x x' = eqTy {n = S n'} tvars (RRef i) x x'
+--   eqTy tvars _ _ _ = False
+--
+-- ||| Equality instance for Mu's only hold if the inner TDef is resolved
+-- Eq (Mu' sp {l=Z} [] td {a = False}) where
+--   (==) y y' {sp=[]} = eqMu [] td y y'
+{-
+-}

--- a/idris2/src/Typedefs/Library.idr
+++ b/idris2/src/Typedefs/Library.idr
@@ -1,0 +1,234 @@
+module Typedefs.Library
+
+import Data.Vect
+
+import Typedefs
+import Typedefs.Idris
+import Typedefs.Names
+import Typedefs.TermWrite
+import Typedefs.TermParse
+
+import Language.JSON
+
+%default total
+
+-- BOOL
+
+public export
+TBool : TDefR 0
+TBool = TSum [T1, T1]
+
+-- NAT
+
+public export
+TNat : TDefR 0
+TNat = TMu [("Z", T1), ("S", TVar 0)]
+
+public export
+TNat1 : TDefR 1
+TNat1 = TMu [("Z", T1), ("S", TVar 0)]
+
+public export
+toNat : Ty [] TNat -> Nat
+toNat (Inn (Left ()))   = Z
+toNat (Inn (Right inn)) = S $ toNat inn
+
+public export
+fromNat : Nat -> Ty [] TNat
+fromNat  Z    = Inn $ Left ()
+fromNat (S n) = Inn $ Right $ fromNat n
+
+-- LIST
+
+public export
+TList : TDefR 1
+TList = TMu [("Nil", T1), ("Cons", TProd [TVar 1, TVar 0])]
+
+public export
+TNil : Ty [a] TList
+TNil = Inn $ Left ()
+
+public export
+TCons : a -> Ty [a] TList -> Ty [a] TList
+TCons x xs = Inn $ Right (x, xs)
+
+-- MAYBE
+
+public export
+TMaybe : TDefR 1
+TMaybe = TMu [("Nothing", T1), ("Just", TVar 1)]
+
+public export
+TNothing : Ty [a] TMaybe
+TNothing  = Inn $ Left ()
+
+public export
+TJust : a -> Ty [a] TMaybe
+TJust = Inn . Right
+
+-- EITHER
+
+public export
+TEither : TDefR 2
+TEither = TMu [("Left", TVar 1), ("Right", TVar 2)]
+
+public export
+TLeft : a -> Ty [a,b] TEither
+TLeft = Inn . Left
+
+public export
+TRight : b -> Ty [a,b] TEither
+TRight = Inn . Right
+
+-- PAIR
+
+public export
+TPair : TDefR 2
+TPair = TProd [TVar 0, TVar 1]
+
+-- STRINGS
+public export
+TString : TDefR 0
+TString = TMu [("String", T0)]
+
+public export
+TString1 : TDefR 1
+TString1 = TMu [("String", T0)]
+
+-- Numeric
+
+public export
+TDouble : TDefR 0
+TDouble = TMu [("Double", T0)]
+
+public export
+TInt : TDefR 0
+TInt = TMu [("Int", T0)]
+
+--------------------------------------------------------------------------------------------------------
+-- Specialisations                                                                                    --
+---                                                                                                   --
+-- There probably is a better way to do this but this will do for now                                 --
+--------------------------------------------------------------------------------------------------------
+
+export
+StandardIdris : SpecialList 10
+StandardIdris = [ (0 ** (TNat, Nat))
+                , (0 ** (TString, String))
+                , (1 ** (TNat1, const Nat))
+                , (1 ** (TString1, const String))
+                , (1 ** (TMaybe, Maybe))
+                , (2 ** (TEither, Either))
+                , (1 ** (TList, List))
+                , (0 ** (TBool, Bool))
+                , (0 ** (TInt, Int))
+                , (0 ** (TDouble, Double))
+                ]
+
+writeListJSON : {0 ts : Vect 1 Type} -> HasGenericWriters JSON ts -> ApplyVect List ts -> JSON
+writeListJSON [f] ls = JArray (map f ls)
+
+writeEitherJSON : {0 ts : Vect 2 Type} -> HasGenericWriters JSON ts -> ApplyVect Either ts -> JSON
+writeEitherJSON [f, g] (Left l)  = JObject [("Left" , f l)]
+writeEitherJSON [f, g] (Right r) = JObject [("Right", g r)]
+
+writeMaybeJSON : {0 ts : Vect 1 Type} -> HasGenericWriters JSON ts -> ApplyVect Maybe ts -> JSON
+writeMaybeJSON [f] y = maybe (JObject []) f y
+
+writeString1JSON : {0 ts : Vect 1 Type} -> HasGenericWriters JSON ts -> ApplyVect (const String) ts -> JSON
+writeString1JSON [_] str = JString str
+
+writeStringJSON : {0 ts : Vect 0 Type} -> HasGenericWriters JSON ts -> ApplyVect String ts -> JSON
+writeStringJSON [] str = JString str
+
+writeNat1JSON : {0 ts : Vect 1 Type} -> HasGenericWriters JSON ts -> ApplyVect (const Nat) ts -> JSON
+writeNat1JSON [_] n = JNumber (cast n)
+
+writeNatJSON : {0 ts : Vect 0 Type} -> HasGenericWriters JSON ts -> ApplyVect Nat ts -> JSON
+writeNatJSON [] n = JNumber (cast n)
+
+writeBoolJSON : {0 ts : Vect 0 Type} -> HasGenericWriters JSON ts -> ApplyVect Bool ts -> JSON
+writeBoolJSON [] n = JBoolean n
+
+writeIntJSON : {0 ts : Vect 0 Type} -> HasGenericWriters JSON ts -> ApplyVect Int ts -> JSON
+writeIntJSON [] n = JNumber (cast n)
+
+writeDoubleJSON : {0 ts : Vect 0 Type} -> HasGenericWriters JSON ts -> ApplyVect Double ts -> JSON
+writeDoubleJSON [] n = JNumber n
+
+export
+StandardContext : HasSpecialisedWriter JSON StandardIdris
+StandardContext = [ writeNatJSON
+                  , writeStringJSON
+                  , writeNat1JSON
+                  , writeString1JSON
+                  , writeMaybeJSON
+                  , writeEitherJSON
+                  , writeListJSON
+                  , writeBoolJSON
+                  , writeIntJSON
+                  , writeDoubleJSON
+                  ]
+
+parseStringJSON : {n : Nat} -> {0 ts : Vect n Type}
+                -> HasParser JSONM JSON ts
+                -> SParser JSONM JSON (ApplyVect (ConstN n String) ts)
+parseStringJSON {n=Z} [] = MkSParser $ \arg => case arg of
+                                               JString n => pure (n, JNull)
+                                               _ => Left (MkErr "Expected String")
+parseStringJSON {n=S n} (x :: xs) = parseStringJSON {n} xs
+
+parseBoolJSON : {n : Nat} -> {0 ts : Vect n Type}
+                -> HasParser JSONM JSON ts
+                -> SParser JSONM JSON (ApplyVect (ConstN n Bool) ts)
+parseBoolJSON {n=Z} [] = MkSParser $ \arg => case arg of
+                                               JBoolean n => pure (n, JNull)
+                                               _ => Left (MkErr "Expected Bool")
+parseBoolJSON {n=S n} (x :: xs) = parseBoolJSON {n} xs
+
+parseNumericJSON : (numeric : Type) -> Cast Double numeric => {n : Nat} -> {0 ts : Vect n Type}
+             -> HasParser JSONM JSON ts
+             -> SParser JSONM JSON (ApplyVect (ConstN n numeric) ts)
+parseNumericJSON _ {n=Z} [] = MkSParser $ \arg => case arg of
+                                             JNumber n => pure (cast n, JNull)
+                                             _ => Left (MkErr "Expected Numeric")
+parseNumericJSON _ {n=S n} (x :: xs) = parseNumericJSON _ {n} xs
+
+parseMaybeJSON : {0 ts : Vect 1 Type}
+              -> HasParser JSONM JSON ts
+              -> SParser JSONM JSON (ApplyVect Maybe ts)
+parseMaybeJSON [p] = MkSParser $ \arg => case run p arg of
+                                              Left err => case arg of
+                                                               (JObject []) => Right (Nothing, JNull)
+                                                               _ => Left err
+                                              Right (v, rest) => Right (Just v, rest)
+
+parseEitherJSON : {0 ts : Vect 2 Type}
+               -> HasParser JSONM JSON ts
+               -> SParser JSONM JSON (ApplyVect Either ts)
+parseEitherJSON [p,q] = ((expectSingleField "Left") *> p)
+                  `alt` ((expectSingleField "Right") *>  q)
+
+parseListJSON : {0 ts : Vect 1 Type} -> HasParser JSONM JSON ts -> SParser JSONM JSON (ApplyVect List ts)
+parseListJSON [MkSParser p] =
+  MkSParser $ \arg =>
+    case arg of
+         (JArray arr) => let
+            f = (map Builtin.fst) . p in flip MkPair JNull <$> traverse f arr
+         _  => Left (MkErr "Expected Array")
+
+export
+StandardParsers : HasSpecialisedParser JSONM JSON StandardIdris
+StandardParsers = [ parseNumericJSON Nat
+                  , parseStringJSON
+                  , parseNumericJSON Nat {n=1}
+                  , parseStringJSON {n=1}
+                  , parseMaybeJSON
+                  , parseEitherJSON
+                  , parseListJSON
+                  , parseBoolJSON
+                  , parseNumericJSON Int
+                  , parseNumericJSON Double]
+
+{-
+-}

--- a/idris2/src/Typedefs/Names.idr
+++ b/idris2/src/Typedefs/Names.idr
@@ -1,0 +1,21 @@
+module Typedefs.Names
+
+import Data.String
+
+%default total
+
+public export
+Name : Type
+Name = String
+
+export
+uppercase : Name -> Name
+uppercase n with (strM n)
+  uppercase (strCons x xs) | (StrCons x xs) = strCons (toUpper x) xs
+  uppercase _              | _              = ""
+
+export
+lowercase : Name -> Name
+lowercase n with (strM n)
+  lowercase (strCons x xs) | (StrCons x xs) = strCons (toLower x) xs
+  lowercase _              | _              = ""

--- a/idris2/src/Typedefs/TermParse.idr
+++ b/idris2/src/Typedefs/TermParse.idr
@@ -1,0 +1,399 @@
+module Typedefs.TermParse
+
+import Typedefs
+import Typedefs.Idris
+
+import Data.Vect
+import Data.Fin
+import Data.String
+import Data.Either
+
+import Language.JSON
+
+%default total
+
+---------------------------------------------------------------------------------------------
+-- Parser & Interfaces                                                                     --
+---------------------------------------------------------------------------------------------
+
+-- A simple Parser, a wrapper for a parsing function `a -> m (b, a)`
+public export
+data SParser : (Type -> Type) -> Type -> Type -> Type where
+  MkSParser : (source -> m (target, source)) -> SParser m source target
+
+export
+run : (SParser m src trg) -> src -> m (trg, src)
+run (MkSParser p) = p
+
+export
+runParser : (Functor m) => SParser m src trg -> src -> m trg
+runParser (MkSParser p) s = fst <$> p s
+
+export
+Monad m => Functor (SParser m s) where
+  map f (MkSParser ma) = MkSParser $ \bs => do
+    (a', bs') <- ma bs
+    pure (f a', bs')
+
+export
+Monad m => Applicative (SParser m s) where
+  pure x = MkSParser (pure . MkPair x)
+
+  (<*>) (MkSParser mf) (MkSParser ma) = MkSParser $ \bs => do
+      (f', bs') <- mf bs
+      (a', bs'') <- ma bs'
+      pure (f' a', bs'')
+
+export
+Monad m => Monad (SParser m s) where
+  (>>=) (MkSParser ma) g = MkSParser $ \bs => do
+      (a', bs') <- ma bs
+      run (g a') bs'
+
+export
+alt : Alternative m => SParser m f a -> SParser m f b -> SParser m f (Either a b)
+alt (MkSParser f) (MkSParser g) =
+  MkSParser $ \arg => map (\(a,r) => (Left a, r)) (f arg)
+                  <|> map (\(b,r) => (Right b, r)) (g arg)
+
+||| A proof that each type variable has a suitable parser
+public export
+data HasParser : (Type -> Type) -> (format : Type) -> Vect n Type -> Type where
+  Nil : HasParser m format []
+  (::) : (SParser m src trg) -> HasParser m src ts -> HasParser m src (trg :: ts)
+
+namespace SpecialisedParser
+  ||| Prove that there is a parser function for every type in the specialisation list
+  public export
+  data HasSpecialisedParser : (m : Type -> Type) -> (format : Type) -> (sp : SpecialList l) -> Type where
+    Nil : HasSpecialisedParser m format []
+    (::) : {n : Nat} -> {def : TDefR n} -> {constr : TypeConstructor n} ->
+           ({0 args : Vect n Type} -> HasParser m fmt args -> SParser m fmt (ApplyVect constr args)) ->
+           HasSpecialisedParser m fmt sps ->
+           HasSpecialisedParser m fmt ((n ** (def, constr)) :: sps)
+
+lookupParser : Monad m => {sp : SpecialList l } -> {format : Type} ->
+               {td : _} ->
+               (e : Elem (n ** (td, constr)) sp) ->
+               (spp : HasSpecialisedParser m format sp) ->
+               {0 args : Vect n Type} -> HasParser m format args ->
+               SParser m format (ApplyVect constr args)
+lookupParser Here (p :: sps) = p
+lookupParser (There e) (p :: sps) = lookupParser e sps
+
+0
+FromTDefToTy : {n : Nat} -> SpecialList l -> Vect n Type -> Vect k (TDefR n) -> Vect k Type
+FromTDefToTy sp types vs = map (Ty' sp types) vs
+
+makeParsers : Monad m => {format : Type} -> {sp : SpecialList l} ->
+              (0 tys : Vect n Type) ->
+              (spp : HasSpecialisedParser m format sp) ->
+              (gen : HasParser m format tys) ->
+              ((tdef : TDefR n) -> SParser m format (Ty' sp tys tdef)) ->
+              (vs : Vect k (TDefR n)) ->
+              HasParser m format (FromTDefToTy sp tys vs)
+makeParsers tys spp gen fn [] = []
+makeParsers tys spp gen fn (td :: tds) = (fn td) :: (makeParsers tys spp gen fn tds)
+
+injection : (sp : SpecialList l) -> (i : Fin (2 + k)) -> (ts : Vect (2 + k) (TDefR n)) ->
+            Ty' sp tvars (index i ts) -> Tnary' sp tvars ts Either
+injection sp FZ      [a, b]             x = Left x
+injection sp (FS FZ) [a, b]             x = Right x
+injection sp FZ     (a :: b :: c :: ts) x = Left x
+injection sp (FS i) (a :: b :: c :: ts) x = Right (injection sp i (b :: c :: ts) x)
+
+failParser : Monad m => (error : m Void) -> SParser m s Void
+failParser error = MkSParser $ \arg => (\v => void v) <$> error
+
+getVar : {n : Nat} -> {0 vs : Vect n Type} -> (i : Fin n) ->  HasParser m format vs -> SParser m format (index i vs)
+getVar FZ (p::ps) = p
+getVar {n = S (S n')} (FS i) (p::ps) =
+  getVar {n = S n'} i ps
+
+
+public export
+interface (Monad m) => TDefDeserialiser (0 m : Type -> Type) (format : Type)  where
+
+  voidError : m Void
+
+  parseProd : {n, k : Nat} -> {0 ts : Vect n Type} -> {sp : SpecialList l} ->
+              HasSpecialisedParser m format sp ->
+              HasParser m format ts ->
+              (args : Vect (2 + k) (TDefR n)) ->
+              SParser m format (Ty' sp ts (TProd args))
+
+  parseSum : {n, k : Nat} -> {0 ts : Vect n Type} -> {sp : SpecialList l} ->
+             HasSpecialisedParser m format sp ->
+             HasParser m format ts ->
+             (args : Vect (2 + k) (TDefR n)) ->
+             SParser m format (Ty' sp ts (TSum args))
+
+  parseMu : SParser m format ()
+  parseMu = MkSParser $ pure . MkPair ()
+
+
+deserialiser : {0 m : Type -> Type} -> {format : Type} -> (TDefDeserialiser m format) =>
+               {sp : SpecialList l} ->
+               {n : Nat} ->
+               {0 ts : Vect n Type} ->
+               (spp : HasSpecialisedParser m format sp) ->
+               HasParser m format ts -> (td : TDefR n) ->
+               SParser m format (Ty' sp ts td)
+deserialiser spp ps T0 = failParser (voidError {m} {format})
+deserialiser spp ps T1 = pure ()
+deserialiser spp ps (TSum {k = k} tds) = parseSum spp ps tds
+deserialiser spp ps (TProd products {k}) = parseProd spp ps products
+deserialiser spp {sp} ps (TMu tds) {ts} with (depLookup sp (TMu tds))
+  deserialiser spp ps (TMu tds) {ts} | Nothing = do
+    () <- parseMu
+    let muParser = assert_total $ deserialiser spp ps (TMu tds)
+    parsed <- assert_total $ deserialiser spp (muParser :: ps) (args tds)
+    let parsed' = the (Ty' sp (Mu' sp ts (args tds) :: ts) (args tds)) (believe_me parsed)
+    let ret = the (Ty' sp ts (TMu tds)) (believe_me (Inn parsed')) -- patching up the type because it doesn't reduce
+    pure ret
+  deserialiser spp ps  (TMu tds) {ts} | Just (def ** constr ** el) =
+    believe_me $ lookupParser el spp ps
+deserialiser spp p (TVar i) = getVar i p
+deserialiser spp p (RRef i) = getVar i p
+deserialiser spp ps {sp} {ts} (TApp (TName name def) xs) with (depLookup sp def)
+  deserialiser spp ps {sp} {ts} (TApp (TName name def) xs) | Nothing =
+    believe_me $ assert_total $ deserialiser spp ps (ap def xs)
+  deserialiser spp ps {sp} {ts} (TApp (TName name def) xs) | Just (_ ** constr ** el) =
+    believe_me $ lookupParser el spp (makeParsers ts spp ps (assert_total $ deserialiser spp ps) xs)
+
+export
+deserialise : {format : Type} -> (Monad m, TDefDeserialiser m format) =>
+              {n : Nat} ->
+              {sp : SpecialList l} ->
+              {ts : Vect n Type} ->
+              HasSpecialisedParser m format sp -> HasParser m format ts -> (td : TDefR n) ->
+              format -> m (Ty' sp ts td)
+deserialise spp ps td = TermParse.runParser $ deserialiser spp ps td
+
+
+---------------------------------------------------------------------------------------------
+-- Strings                                                                                 --
+----                                                                                       --
+-- The string parser is different so we leave it in its own namespace without implementing --
+-- the common TDefDeserialiser interface.                                                  --
+---------------------------------------------------------------------------------------------
+
+{-
+namespace StringParser
+  Parser' : Type -> Nat -> Type
+  Parser' = Parser TParsecU (sizedtok Char)
+
+  data StringParsers : Vect n Type -> Nat -> Type where
+    Nil : StringParsers Nil m
+    (::) : {xs : Vect n Type} -> Parser' x m -> StringParsers xs m -> StringParsers (x :: xs) m
+
+  mutual
+    muParser : {td : TDefR (S n)} -> (ts : Vect n Type) -> All (StringParsers ts :-> Parser' (Mu ts td))
+    muParser {td} ts ps = assert_total $ map (\ty => Inn' {tvars = ts} {m = td} ty) $
+                          parens (rand (string "inn")
+                                       (withSpaces $ chooseParser td ((Mu ts td)::ts) ((muParser ts ps)::ps)))
+
+    chooseParser : (t : TDefR n) -> (ts : Vect n Type) -> All (StringParsers ts :-> Parser' (Ty ts t))
+    chooseParser T0                    _         _         = fail
+    chooseParser T1                    _         _         = cmap () $ string "()"
+    chooseParser (TSum [x,y])          ts        ps        =
+      parens $ sum (rand (string "left")  (withSpaces $ chooseParser x ts ps))
+                   (rand (string "right") (withSpaces $ chooseParser y ts ps))
+    chooseParser (TSum (x::y::z::zs))  ts        ps        =
+      parens $ sum (rand (string "left")  (withSpaces $ chooseParser x ts ps))
+                   (rand (string "right") (withSpaces $ assert_total $ chooseParser (TSum (y::z::zs)) ts ps))
+    chooseParser (TProd [x,y])         ts        ps        =
+      parens $ rand (string "both") (and (withSpaces $ chooseParser x ts ps)
+                                         (withSpaces $ chooseParser y ts ps))
+    chooseParser (TProd (x::y::z::zs)) ts        ps        =
+      parens $ rand (string "both") (and (withSpaces $ chooseParser x ts ps)
+                                         (withSpaces $ assert_total $ chooseParser (TProd (y::z::zs)) ts ps))
+    chooseParser (TVar FZ)             (_::_)    (p::_)    = p
+    chooseParser (TVar (FS FZ))        (_::_::_) (_::p::_) = p
+    chooseParser (TVar (FS (FS i)))    (_::ts)   (_::ps)   = chooseParser (TVar (FS i)) ts ps
+    chooseParser (TApp (TName n def) xs)           ts        ps        =
+      assert_total $ chooseParser (ap def xs) ts ps
+    chooseParser (RRef FZ)             (_::_)    (p::_)    = p
+    chooseParser (RRef (FS FZ))        (_::_::_) (_::p::_) = p
+    chooseParser (RRef (FS (FS i)))    (_::ts)   (_::ps)   = chooseParser (RRef (FS i)) ts ps
+    chooseParser (TMu td)              ts        ps        =
+       map (\ty => Inn' {tvars = ts} {m = args td} ty) $
+       parens (rand (string "inn")
+                    (withSpaces $ assert_total $ chooseParser (args td) ((Mu ts (args td))::ts)
+                                                                        ((muParser ts ps)::ps)))
+
+  deserialiseStr : {ts : Vect n Type} -> All (StringParsers ts) -> (td : TDefR n) -> String -> Maybe (Ty ts td)
+  deserialiseStr {ts} ps td s  = parseMaybe s (chooseParser td ts ps)
+-}
+
+---------------------------------------------------------------------------------------------
+-- Binary                                                                                  --
+---------------------------------------------------------------------------------------------
+
+{-
+fail : s -[Maybe]-> a
+fail = MkSParser $ const Nothing
+
+||| Interprets the first byte as an Int, and returns the rest of the bytestring, if possible
+deserialiseInt : (n : Nat) -> (Bytes -[Maybe]-> (Fin n))
+deserialiseInt n = MkSParser $ \bs => case (consView bs) of
+    Nil => Nothing
+    Cons b bs' => flip MkPair bs' <$> integerToFin (prim__zextB8_BigInt b) n
+
+export
+TDefDeserialiser Maybe Bytes where
+
+  voidError = Nothing
+
+  parseSum spp ps tds {sp} {k} = do
+    i <- deserialiseInt (2 + k)
+    t' <- assert_total $ deserialiser spp ps (index i tds)
+    pure (injection sp i tds t')
+
+  parseProd spp ps [a,b] = do
+    ta <- assert_total $ deserialiser spp ps a
+    tb <- assert_total $ deserialiser spp ps b
+    pure (ta, tb)
+
+  parseProd spp ps (a :: b :: c :: tds) = do
+    ta <- assert_total $ deserialiser spp ps a
+    t' <- assert_total $ deserialiser spp ps (TProd (b :: c :: tds))
+    pure (ta, t')
+
+-}
+---------------------------------------------------------------------------------------------
+-- JSON                                                                                    --
+---------------------------------------------------------------------------------------------
+
+public export
+data JSONErr : Type where
+  MkErr : String -> JSONErr
+
+public export
+Alternative (Either JSONErr) where
+  empty = Left (MkErr "JSON Error")
+  (<|>) (Right v) _ = Right v
+  (<|>) _ v = v
+
+||| Errors when parsing JSON
+public export
+JSONM : Type -> Type
+JSONM = Either JSONErr
+
+||| Type of parsers that consume JSON
+public export
+JParser : Type -> Type
+JParser = SParser (Either JSONErr) JSON
+
+||| Expect JSON is an object and return its fields
+parseObject : JParser (List (String, JSON))
+parseObject = MkSParser parse
+  where
+    parse : JSON -> JSONM ((List (String, JSON)), JSON)
+    parse (JObject ls) = Right (ls, JNull)
+    parse _ = Left (MkErr "expected Object")
+
+||| Expects JSON is an integer value
+parseInt : JParser Int
+parseInt = MkSParser parse
+  where
+    parse : JSON -> JSONM (Int, JSON)
+    parse (JNumber n) = pure ((cast n), JNull)
+    parse _ = Left (MkErr "expected Int")
+
+||| check if the key starts with an underscore and if its smaller than 2 + k
+parseKey : (k : Nat) -> String -> JSONM (Fin (2 + k))
+parseKey k "" = Left (MkErr "Invalid key: empty")
+parseKey k str = do '_' <- safeHead str | _ => Left (MkErr "Invalid key: '\{str}'")
+                    rest <- safeTail str
+                    let i = parsePositive rest
+                    index <- maybeToEither (MkErr "Invalid key") i
+                    maybeToEither (MkErr "Invalid Key") $ natToFin index (2 + k)
+    where
+      safeStrOp : (String -> a) -> String -> JSONM a
+      safeStrOp op str = if length str > 0 then Right (op str)
+                                           else Left (MkErr "expected index")
+      safeHead : String -> JSONM Char
+      safeHead = assert_total $ safeStrOp (flip strIndex 0)
+      safeTail : String -> JSONM String
+      safeTail = assert_total $ safeStrOp strTail
+
+namespace ParseProduct
+  ||| A proof that each element of a product has been successfully parsed
+  public export
+  data ParseProd : (sp : SpecialList l) -> Vect n Type -> Vect k (TDefR n) -> Type where
+    Nil : ParseProd sp vs []
+    (::) : {td : TDefR n} -> {sp : SpecialList l} -> (parsed : Ty' sp vs td) ->
+           ParseProd sp vs ts -> ParseProd sp vs (td::ts)
+
+injProd : {0 vs : Vect n Type} -> {vec : Vect (2 + k) (TDefR n)} -> (sp : SpecialList l) ->
+          ParseProd sp vs vec -> Tnary' sp vs vec Pair
+injProd sp [a, b] = (a, b)
+injProd sp (a :: b :: x :: xs) = (a , injProd sp (b :: x :: xs))
+
+jsonFail : String -> SParser JSONM a b
+jsonFail str = MkSParser (const $ Left (MkErr str))
+
+-- we need to check all keys are in increasing order and of the format _X from 0 to l
+parseVect : List (String, JSON) -> (l : Nat) -> JSONM (Vect l JSON)
+parseVect ls n = case decEq (length ls) n of
+                      Yes prf => rewrite sym prf in pure $ map snd (fromList ls)
+                      No _ => Left (MkErr "incompatible lengths: \{show (length ls)}, expected \{show n}")
+
+||| Lift a function into a parser that operates on the value but does not consume it
+liftParse : Monad m => {0 a : Type} -> (a -> m b) -> (SParser m a b)
+liftParse f = MkSParser (\v => flip MkPair v <$> f v)
+
+liftVal : Monad m => m b -> SParser m a b
+liftVal v = liftParse (const v)
+
+||| Parses an object with a single field. Returns the parsed key and the json as leftover
+parseSingleObject : JParser String
+parseSingleObject = do
+    [v] <- parseObject
+        | _ => jsonFail "Object doens't contain exactly 1 element"
+    MkSParser (const $ pure v)
+
+export
+expectSingleField : String -> JParser ()
+expectSingleField str = do
+  parsed <- parseSingleObject
+  if parsed == str then pure ()
+                   else jsonFail $ "expected with single field " ++ str ++ " got " ++ parsed ++ " instead"
+
+toParsedProd : (sp : SpecialList l) ->
+               (0 ts : Vect n Type) ->
+               ((td : TDefR n) -> JSON -> JSONM (Ty' sp ts td)) ->
+               (tds : Vect k (TDefR n)) ->
+               (Vect k JSON) -> JSONM (ParseProd sp ts tds)
+toParsedProd sp ts rec [] [] {k = Z} = pure []
+toParsedProd sp ts rec (t::tds) (j::js) {k = (S k)} = do
+  r <- rec t j
+  rs <- toParsedProd sp ts rec tds js
+  pure $ r :: rs
+
+export
+TDefDeserialiser (Either JSONErr) JSON where
+
+  voidError = Left (MkErr "parsing Void")
+
+  -- mu is an object with a single field called "inn"
+  parseMu = expectSingleField "inn"
+
+  parseSum spp ps tds {k} {sp} = do
+    key <- parseSingleObject
+    let (Right key') = parseKey k key
+      | Left (MkErr err) => jsonFail err
+    t' <- assert_total $ deserialiser spp ps (index key' tds)
+    pure (injection sp key' tds t')
+
+  parseProd spp ps tds {n} {k} {ts} {sp} = do
+      keyValues <- parseObject
+      vec <- liftVal $ parseVect keyValues (2 + k)
+      res <- liftVal $ toParsedProd sp ts
+               (\tdef => TermParse.runParser $ assert_total $ deserialiser spp ps tdef) tds vec
+      pure $ injProd sp res
+
+
+{-
+-}

--- a/idris2/src/Typedefs/TermWrite.idr
+++ b/idris2/src/Typedefs/TermWrite.idr
@@ -1,0 +1,245 @@
+module Typedefs.TermWrite
+
+import Typedefs
+import Typedefs.Idris
+import Typedefs.DependentLookup
+import Typedefs.DecEq
+import Typedefs.Names
+
+import Data.List
+import Data.Vect
+import Data.Vect.Elem
+
+import Language.JSON
+
+%default total
+
+-- serialization
+
+||| A proof that each Type in the indexed list can be converted into the target type
+public export
+data HasGenericWriters : (0 target : Type) -> (0 types : Vect n Type) -> Type where
+  Nil  : HasGenericWriters a Nil
+  (::) : (src -> trg) -> HasGenericWriters trg xs -> HasGenericWriters trg (src :: xs)
+
+namespace SpecialisedWriters
+  ||| Prove that there exist a writer function for every type in the specialisation list
+  public export
+  data HasSpecialisedWriter : (0 target : Type) -> (0 specialised : SpecialList l) -> Type where
+    Nil  : HasSpecialisedWriter a []
+    (::) : {n : Nat} -> {def : TDefR n} -> {constr : TypeConstructor n} ->
+           ({0 args : Vect n Type} -> HasGenericWriters a args -> ApplyVect constr args -> a) ->
+           HasSpecialisedWriter a xs ->
+           HasSpecialisedWriter a ((n ** (def, constr)) :: xs)
+
+||| Lookup in the specialised context for the function that converts a special type to its target representation
+lookupTypeReplacement : {td : TDefR n} ->
+                        {0 sp : SpecialList l} ->
+                        (e : Elem (n ** (td, constr)) sp) ->
+                        {0 target : Type} ->
+                        (sw : HasSpecialisedWriter target sp) ->
+                        {0 args : Vect n Type} -> HasGenericWriters target args ->
+                        ApplyVect constr args -> target
+lookupTypeReplacement Here (s :: sp) = s
+lookupTypeReplacement (There e) (s :: sp) = lookupTypeReplacement e sp
+
+||| Returns the index and the type of a sum from an array of TDefs
+injectionInv : (ts : Vect (2 + k) (TDefR n)) -> Tnary' sp tvars ts Either -> (i : Fin (2 + k) ** Ty' sp tvars (index i ts))
+injectionInv [a,b] (Left x) = (0 ** x)
+injectionInv [a,b] (Right y) = (1 ** y)
+injectionInv (a::b::c::tds) (Left x) = (0 ** x)
+injectionInv (a::b::c::tds) (Right y) =
+  let (i' ** y') = injectionInv (b::c::tds) y in (FS i' ** y')
+
+partial
+getVariable : {0 ts : Vect (S n) Type} ->
+              (i : Fin (S n)) ->
+              (ws : HasGenericWriters target ts) -> index i ts -> target
+getVariable FZ (f :: z) x {ts = (y :: xs)} = f x
+getVariable (FS FZ) (_ :: f :: ws) x = f x
+getVariable (FS (FS y)) (w :: ws) x = getVariable (FS y) ws x
+-- getVariable (FS _) _ _ = ?This_is_a_bug
+
+total
+getVariable' : {0 ts : Vect (S n) Type} ->
+               (i : Fin (S n)) ->
+               (ws : HasGenericWriters target ts) -> index i ts -> target
+getVariable' i ws = assert_total $ getVariable i ws
+
+||| Given a vector of TDef n and n types to fill its holes, return the vector of types correpondng to those tdefs
+0
+FromTDefToTy : {n : Nat} -> (0 _ : SpecialList l) -> (types : Vect n Type) -> Vect k (TDefR n) -> Vect k Type
+FromTDefToTy sp types [] = []
+FromTDefToTy sp types (v :: vs) = assert_total (Ty' sp types v) :: FromTDefToTy sp types vs
+
+||| Magically generate the writers for a vector of TDefs in argument position
+|||
+||| For some reason this couldn't be placed in a where-clause inside `serialise`. The lookup for
+||| instances of `TDefSerialiser` would get confused and say that there aren't any suitable instances
+||| for `serialiser`. That's why we simply pass it as a partially applied function
+makeWriters : {target : Type} -> {0 sp : SpecialList l} ->
+              (0 tys : Vect n Type) ->
+              (spp : HasSpecialisedWriter target sp) ->
+              (gen : HasGenericWriters target tys) ->
+              ((tdef : TDefR n) -> Ty' sp tys tdef -> target) ->
+              (vs : Vect k (TDefR n)) ->
+              HasGenericWriters target (FromTDefToTy sp tys vs)
+makeWriters tys spp gen fn [] = []
+makeWriters tys spp gen fn (td :: tds) = (fn td) :: (makeWriters tys spp gen fn tds)
+
+public export
+interface TDefSerialiser (target : Type) where
+  unitVal : target
+
+  ||| How to convert a sum into a term in the target type
+  foldSum : {n, l, k : Nat} -> {0 ts : Vect n Type} -> {sp : SpecialList l} ->
+            HasSpecialisedWriter target sp ->
+            HasGenericWriters target ts ->
+            (args : Vect (2 + k) (TDefR n)) ->
+            Ty' sp ts (TSum args) -> target
+
+  ||| How to convert a prod into a term in the target type
+  foldProd : {n, l, k: Nat} -> {0 ts : Vect n Type} -> {sp : SpecialList l} ->
+             HasSpecialisedWriter target sp ->
+             HasGenericWriters target ts ->
+             (args : Vect (2 + k) (TDefR n)) ->
+             Ty' sp ts (TProd args) -> target
+
+  ||| How to decorate a mu term
+  muPrefix : target -> target
+
+||| Convert an arbitrary TDef into a term in the target format
+|||
+||| Given an arbitrary specialisation list, a proof that every specialised type has a writer
+||| and a proof that every type that will inhabit each type variable also has a writer, return
+||| a function that will take a Typedef and its Idris term and convert it into a term in the
+||| target format
+||| @n : The number of free variables in the Typedefs
+||| @ts : The vector of types that will inhabit the free variables
+||| @sp : The specialisation list of types that will be replaced by a specialised version
+||| @spp : A proof that every specialised constructor and its arguments have a writer
+||| @ws : A proof that every type parameter has a writer
+serialise : {target : Type} -> TDefSerialiser target =>
+            {n, l : Nat} -> {0 ts : Vect n Type} -> {sp : SpecialList l} ->
+            (spp : HasSpecialisedWriter target sp) ->
+            (ws : HasGenericWriters target ts) ->
+            (td : TDefR n) ->
+            Ty' sp ts td ->
+            target
+serialise spp ws T1           x = unitVal
+serialise spp ws (TSum args)  x = foldSum spp ws args x
+serialise spp ws (TProd args) x = foldProd spp ws args x
+serialise spp ws (RRef i)     x = getVariable' i ws x
+serialise spp ws (TVar i)     x = getVariable' i ws x
+
+-- first lookup the specialisation context
+serialise spp {sp} {ts} {n} ws (TApp (TName _ def) ys) x with (depLookup sp def)
+  serialise spp {sp} {ts} {n} ws (TApp (TName _ def) ys) x | Nothing =
+
+    -- if there is nothing, proceed as is nothing changed
+    -- if we had a proof that no substitutions we performed we could remove the `believe_me`
+    assert_total $ serialise spp ws (def `ap` ys) (believe_me x)
+  serialise spp {sp} {ts} {n} ws (TApp (TName _ def) ys) x | (Just (d ** constr ** prf)) =
+
+    -- Otherwise, replace the type using the magic lookup.
+    -- This requires to pass a list of writer functions for the type arguments. Since the
+    -- type arguments come from the vector of TDefs passed in arguments to the TApp we
+    -- generate a new `HasGenericWriter` using `serialise` itself a writer function from
+    -- source type (each TDef in the argument vector) to the target type.
+    lookupTypeReplacement prf spp (makeWriters ts spp ws (assert_total $ serialise spp ws) ys) (believe_me x)
+
+-- first lookup the specialisation context
+serialise spp {sp} writers (TMu td) x {ts} with (depLookup sp (TMu td)) proof p
+  serialise spp {sp} writers (TMu td) x {ts} | Nothing = 
+      let writer : Mu ts (args td) -> target
+          writer = believe_me $ serialise [] writers (TMu td) -- this should be fixed after #1419
+          newX : Mu' sp tvars (args td) --
+          newX = believe_me x in        -- Those three ridiculous lines are to match on `x` since Ty does no reduce
+      let (Inn x') = newX               --
+          inner = assert_total $ serialise spp {ts=(Mu ts (args td))::ts} (writer :: writers) (args td) (believe_me x')
+       in believe_me {b=target} (muPrefix inner)
+  serialise spp {sp = sp} writers (TMu td) x {ts = ts} | (Just (def ** constr ** prf)) =
+    lookupTypeReplacement prf spp {args=ts} writers (believe_me x) -- again, this would not be necessary if it wasn't
+                                                                   -- for #1419
+---------------------------------------------------------------------------------------------
+-- Strings                                                                                 --
+---------------------------------------------------------------------------------------------
+
+public export
+TDefSerialiser String where
+
+  unitVal = "()"
+
+  foldSum sp ws ([x,_]) (Left l) =
+    parens $ "left "  ++ assert_total (serialise sp ws x l)
+  foldSum sp ws ([_,y]) (Right r) =
+    parens $ "right " ++ assert_total (serialise sp ws y r)
+  foldSum sp ws ((x::_::_::_)) (Left l) =
+    parens $ "left "  ++ assert_total (serialise sp ws x l)
+  foldSum sp ws ((_::y::z::zs)) (Right r) =
+    parens $ "right " ++ assert_total (serialise sp ws (TSum (y::z::zs)) r)
+
+  foldProd sp ws ([x,y]) (a, b) =
+    parens $ "both "  ++ assert_total (serialise sp ws x a) ++ " " ++ assert_total (serialise sp ws y b)
+  foldProd sp ws ((x::y::z::zs)) (a, b) =
+    parens $ "both "  ++ assert_total (serialise sp ws x a) ++ " " ++ assert_total (serialise sp ws (TProd (y::z::zs)) b)
+
+  muPrefix inner = "(inn " ++ inner ++ ")"
+
+---------------------------------------------------------------------------------------------
+-- Binary                                                                                  --
+---------------------------------------------------------------------------------------------
+--
+-- serializeInt : {n : Nat} -> (Fin n) -> Bytes
+-- serializeInt x = pack [prim__truncBigInt_B8 (finToInteger x)]
+--
+-- public export
+-- TDefSerialiser Bytes where
+--
+--   unitVal = empty
+--
+--   foldSum sp ws args tv =
+--      let (i ** x') = injectionInv args tv in
+--      (serializeInt i) ++ (assert_total $ serialise sp ws (index i args) x')
+--
+--   foldProd sp ws [a, b] (x, y) =
+--     (serialise sp ws a x) ++ (serialise sp ws b y)
+--   foldProd sp ws (a::b::c::tds) (x, y) =
+--     (serialise sp ws a x) ++ (serialise sp ws (TProd (b::c::tds))) y
+--
+--   muPrefix = id
+
+---------------------------------------------------------------------------------------------
+-- JSON                                                                                    --
+---------------------------------------------------------------------------------------------
+
+makeFields : Nat -> List String
+makeFields n = map (("_" ++) . show) [0 .. n]
+
+public export
+TDefSerialiser JSON where
+
+  unitVal = JObject []
+
+  -- Products are serialised as { "_0" : a, "_1" : b, ... , "_x" : n } where the key stands for the
+  -- index in the product
+  foldProd sp ws args tv =  let res = serialiseTNaryProd sp ws args tv in
+                            JObject (zip (makeFields (length args)) res)
+    where
+      serialiseTNaryProd : {k : Nat} -> {sp : SpecialList l} ->
+                           HasSpecialisedWriter JSON sp -> HasGenericWriters JSON ts ->
+                           (defs: Vect (2 + k) (TDefR n)) ->
+                           Tnary' sp ts defs Pair -> List JSON
+      serialiseTNaryProd sp writers [x, y] {k=Z} (a, b) =
+        [assert_total (serialise sp writers x a), assert_total (serialise sp writers y b)]
+      serialiseTNaryProd sp writers (x :: y :: z :: zs) (a , b) =
+        assert_total (serialise sp writers x a) :: serialiseTNaryProd sp writers (y :: z :: zs) b
+
+  -- Mus are identified by an obect with a single `inn` field
+  muPrefix inner =  JObject [("inn",  inner)]
+
+  -- Sums are serialized as { "_x" : term } where x is the index in the sum
+  foldSum sp ws args tv =
+    let (i ** def) = injectionInv args tv in
+        JObject [("_"++ show (finToNat i), assert_total $ serialise sp ws (index i args) def)]
+


### PR DESCRIPTION
This ports Typedefs to idris2 using the writer and parsers within idris2 with the following caveats:

- external backends are not supported
- writing tdefs from files not supported (TParsec not ported to Idris2)
- Type providers are not supported, they are not available in idris2 (yet?)